### PR TITLE
Add guide for handling merge conflicts

### DIFF
--- a/plugins/developer/commands/handle-conflicts.md
+++ b/plugins/developer/commands/handle-conflicts.md
@@ -5,14 +5,14 @@ allowed-tools: Bash, Read, Write, Grep, Glob
 
 # Resolving conflicts so that humans can later review them
 
-* make a list of the conflicted files in .scratch/conflicts-$hash.md
-* commit the conflicted files, including the conflict markers
+Resolve conflicts using the following process: 
+
+* make a simple list of the conflicted files in .scratch/conflicts-$hash.md
 * prepare a plan file in .scratch containing the following for every file:
   * conflicted file name
   * (see the commits on both sides that introduced the conflict)
-  * understanding of the remote changes 
-  * understanding of the local changes
+  * understanding of why the remote changes occurred
+  * understanding of why the local changes occurred
   * explanation why the conflict occurs
   * suggested resolution of the conflict
   * assessment if the conflict is caused by lint fix or actual conflicting change
-* output a git command that can be used to squash the commit, so that no conflict markers ever get to the base branch


### PR DESCRIPTION
This document outlines a method for handling merge conflicts in a way that facilitates future review, detailing steps for documenting conflicts and resolutions.