### PR TITLE
feat(developer): add keboola-architecture skill with bundled C4 model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "developer",
       "description": "Developer toolkit with specialized agents for code review, security analysis, and GitHub PR review processing",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "source": "./plugins/developer",
       "category": "development"
     },

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A comprehensive toolkit for developers including specialized agents for code rev
 **Features:**
 - 🤖 **Agents**: Code review, security analysis, code mess detection & fixing
 - ⚡ **Commands**: Task management, PR creation, merge conflict resolution, GitHub PR review processing
+- 📚 **Skills**: Keboola Architecture (C4 model bundled for impact analysis & dependency questions)
 - 📊 **Scripts**: Context window progress bar for statusline
 - 🔌 **MCP Server**: Linear integration
 

--- a/plugins/developer/.claude-plugin/plugin.json
+++ b/plugins/developer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Developer toolkit with specialized agents for code review and security analysis",
   "author": {
     "name": "Keboola :(){:|:&};: s.r.o.",

--- a/plugins/developer/README.md
+++ b/plugins/developer/README.md
@@ -196,6 +196,28 @@ Systematically process GitHub PR review comments by fetching threads to local JS
 
 ---
 
+## 📚 Skills
+
+### Keboola Architecture (C4)
+
+**Skill**: `keboola-architecture`
+
+Bundled snapshot of the Keboola platform's C4 architecture model (Structurizr DSL + per-service findings reports). Use when answering impact analysis, service dependency, or platform topology questions — *"if service X is down, what breaks?"*, *"if I change service X's API, who needs to update?"*, *"what does service Y depend on?"*
+
+**Contents:**
+- L1 systems, L2 containers, L3 components and their inter-service and cloud-vendor edges
+- Methodology and design decisions (`c4-approach.md`)
+- Non-automatable domain rules (`service-knowledge.md`)
+- `scripts/sync.sh` to refresh from the upstream private repo (`keboola/platform-architecture-and-concepts`)
+
+**Caveats** (built into the skill):
+- Model is **idealized** — shows all cloud variants per service, real impact on a single stack may be smaller
+- Scanning is **one-directional**; inbound edges only reliable once the caller has been scanned
+- Cloud vendors are hidden at L2; "runs on Kubernetes" is implicit everywhere
+- Snapshot drifts over time — re-run `sync.sh` when answering edge cases
+
+---
+
 ## 🔌 MCP Servers
 
 ### Linear

--- a/plugins/developer/skills/keboola-architecture/SKILL.md
+++ b/plugins/developer/skills/keboola-architecture/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: keboola-architecture
+description: >
+  Use when answering impact analysis, service dependency, or platform topology questions
+  about Keboola — "if service X is down, what breaks?", "if I change service X's API, who
+  needs to update?", "what does Y depend on?", "which cloud services does Z use?". Also use
+  when reviewing changes to inter-service contracts, planning a new service, or onboarding
+  to an unfamiliar Keboola service. Contains a snapshot of the C4 architecture model for
+  the Keboola platform (Structurizr DSL + findings reports).
+---
+
+# Keboola Platform Architecture (C4)
+
+A snapshot of the Keboola platform's C4 architecture model. Use it to answer impact analysis,
+dependency, and topology questions without scanning the source code of every service.
+
+The model uses three C4 levels:
+- **L1** — software systems Keboola interacts with (platforms, satellites, cloud vendors)
+- **L2** — independently deployed containers (services) inside the Keboola platform
+- **L3** — components inside a container plus its inter-service and cloud-vendor edges
+
+## Source of truth and freshness
+
+The authoritative content lives in `keboola/platform-architecture-and-concepts`, folders
+**`c4/` and `c4-docs/` ONLY** — every other folder in that repo (`apis/`, `clients/`,
+`concepts/`, `services/`) and the root `README.md` are **obsolete** and must be ignored.
+
+This skill ships a **point-in-time snapshot** under `references/`. For verification of edge
+cases or when the answer is uncertain, fetch the current version with
+`./scripts/sync.sh` (requires `gh` auth with access to the private repo).
+
+## When to read which file
+
+| Question | File |
+|---|---|
+| Outbound dependencies of service X | `references/c4/l3/<X>.dsl` (inter-service) + `references/c4/l3/<X>-external.dsl` (cloud) |
+| Who calls service X (inbound) | grep `c4/l3/*.dsl` for X's component IDs — inbound edges live in the **caller's** file |
+| Human-readable findings for service X | `references/c4/l3/<X>.md` |
+| Full container inventory | `references/c4/l2/containers.dsl` and `references/c4/list of services.md` |
+| Top-level systems + personas | `references/c4/model/model.dsl` |
+| Domain rules that can't be inferred from code | `references/c4/service-knowledge.md` |
+| Methodology, level rules, design decisions | `references/c4-docs/c4-approach.md` |
+| Granular cloud-vendor services + IDs | `references/c4/l3/cloud-resources.dsl` |
+| Views and styles | `references/c4/views/views.dsl` |
+
+Start with `references/c4-docs/c4-approach.md` if the question is *how* the model is
+structured rather than *what* it contains.
+
+## Caveats (read before drawing conclusions)
+
+- **Idealized model.** Each service shows relationships to **all** cloud variants it
+  supports, even though a given stack uses only one cloud at a time. Impact analysis is
+  therefore also idealized — real impact on any single stack may be smaller.
+- **One-directional scanning.** The model is built by scanning each service's outbound
+  deps. Inbound edges become reliable only after the calling service has been scanned.
+  Check the "Current Status" table in `c4-approach.md` for coverage gaps.
+- **No deployment-time mechanisms.** Helm hooks, migration Jobs, and schema seeders are
+  intentionally omitted.
+- **Shared infrastructure ≠ shared resource.** A shared node (Service Bus, KMS, database)
+  on the diagram does not imply shared queues/keys/schemas — the edge label is what
+  matters.
+- **L2 hides cloud vendors.** Cloud dependencies appear at L1 (aggregated) and L3
+  (granular), never at L2. "Runs on Kubernetes" is implicit everywhere.
+
+## Working directory context
+
+Scripts in this skill auto-detect their own location. The user is in **their project
+root** when invoking the skill — do not `cd` into the skill directory. Use absolute paths
+or `$SKILL_DIR`-relative paths when reading `references/`.
+
+## Updating the snapshot
+
+```bash
+./scripts/sync.sh         # pulls latest c4/ and c4-docs/c4-approach.md from the upstream
+                          # repo via `gh` and overwrites references/. Requires gh auth.
+```
+
+The snapshot drifts from upstream over time. If a question hinges on a recently changed
+service edge, re-run `sync.sh` before answering.

--- a/plugins/developer/skills/keboola-architecture/references/c4-docs/c4-approach.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4-docs/c4-approach.md
@@ -1,0 +1,426 @@
+---
+marp: true
+theme: default
+paginate: true
+style: |
+  section {
+    font-family: 'Segoe UI', sans-serif;
+    font-size: 1.1em;
+  }
+  h1 { color: #1a5276; border-bottom: 2px solid #1a5276; padding-bottom: 0.2em; }
+  h2 { color: #2e86c1; }
+  code { background: #eaf2ff; padding: 0.1em 0.4em; border-radius: 3px; }
+  table { font-size: 0.85em; }
+  th { background: #2e86c1; color: white; }
+  tr:nth-child(even) { background: #f0f7ff; }
+---
+
+# Keboola Platform
+## C4 Architecture Model
+
+Approach and decisions
+
+---
+
+## Why?
+
+The platform is **26+ independently deployed services**. Without documentation,
+answering questions requires digging through code or relying on tribal knowledge.
+
+**Primary goal: impact analysis — of two kinds:**
+
+- **Operational impact** — if the Storage API is down, what breaks? Who can't log in?
+- **Development impact** — if I change the Queue API contract, which services need to be updated? Which teams do I need to talk to?
+
+Both kinds of questions should be answerable from the diagram, not from memory.
+
+---
+
+## What is C4?
+
+C4 is a set of **hierarchical abstractions** for describing software architecture.
+Each level zooms in on the previous one.
+
+| Element | Definition |
+|---|---|
+| **Person** | A human role or actor that interacts with the system (one person can play multiple roles). **An AI agent is not a Person** — it's a tool a Person uses. |
+| **Software System** | The highest level of abstraction — something that delivers value to a person |
+| **Container** | An independently deployable unit within a system (process, service, database, etc.) |
+| **Component** | A grouping of related functionality within a container (e.g. a Deployment, a CronJob) |
+
+The notation is intentionally **technology-agnostic** — a Container can be a PHP service,
+a Go binary, a Kubernetes CronJob, or a managed cloud database.
+
+---
+
+## C4 Levels
+
+| Level | View | Question answered |
+|---|---|---|
+| **L1** | System Context | Who uses the system and what external systems does it interact with? |
+| **L2** | Container | What independently deployable units make up the system? |
+| **L3** | Component | What runs inside a single container and how does it connect to other things? |
+
+Each level is a separate diagram. Readers navigate from the big picture down to the
+detail they need — no single diagram tries to show everything.
+
+---
+
+## Domain Services, Not Microservices
+
+Keboola services are **domain services** — larger than microservices, each owning
+its own database and cloud resources, but smaller than a monolith.
+
+This shapes how C4 levels are applied:
+
+- **One L2 box per functional domain** — even if the domain spans multiple repos
+  (e.g. `queue` = job-queue + job-queue-daemon + runner)
+- **L3 exposes internal structure** — async workers, REST APIs, and cron jobs
+  are separate components because they have different dependencies and failure modes
+- **Connection (SAPI) is decomposed** into three API surfaces — Storage API, Manage API, and PAYG API — even though they deploy as one container
+
+---
+
+## The Core Decision: Levels of Detail
+
+The temptation is to show **every relationship at every level** — but that adds
+enormous noise:
+
+- **Human readers** of cluttered diagrams will simply stop looking
+- **AI readers** (LLMs consuming the DSL) waste context on irrelevant edges — and produce worse impact analysis as a result
+
+The hardest question in C4 for a platform like Keboola:
+**where do cloud dependencies belong?**
+
+| Level | Contains | Excludes |
+|---|---|---|
+| **L1** | Platform systems, satellite systems, cloud vendors (aggregated) | Internal service detail |
+| **L2** | Platform containers and their inter-service relationships | Cloud vendor services |
+| **L3** | Internal components (API, workers, cron jobs), granular cloud services | — |
+
+Every service depends on cloud infrastructure — showing it at L2 would clutter
+every diagram with the same boxes and hide the actual service relationships.
+At L3, cloud dependencies are scoped to the specific component that uses them.
+
+---
+
+## Idealized Model
+
+The model is intentionally **idealized**: each service shows relationships to all cloud
+variants it supports, even though each deployed stack uses only one cloud at a time.
+
+This makes the diagrams independent of which specific stack is being examined and shows
+the full dependency surface of the service — useful for architectural analysis and
+onboarding.
+
+**Consequence: impact analysis is also idealized.** The diagram shows which services
+*could* be affected by a change; the real impact on any given stack may be smaller.
+For example, "Billing is down" has no effect on a stack that doesn't deploy Billing
+at all. Narrowing idealized impact down to per-stack reality is future work.
+
+---
+
+## Why C4? Why Structurizr DSL?
+
+Alternatives considered:
+
+| Option | Why not chosen |
+|---|---|
+| Informal box-and-arrow (Mermaid/PlantUML) | No enforced structure — every diagram ends up different |
+| UML component diagrams | Precise but doesn't prescribe *what* to draw or *for whom* |
+| Arc42 | Good documentation framework, but doesn't define diagram structure |
+| Service graph (Backstage) | Better for runtime data; requires tooling adoption across teams |
+
+**C4 + Structurizr DSL was chosen because:**
+
+- Enforces a consistent four-level hierarchy — structure separate from notation
+- **Plain text** → stored in Git, reviewed in PRs, diffable like code
+- **`!include`** → model split into per-service files; adding a service doesn't touch existing ones
+- **Single model, multiple views** → relationships defined once, rendered in L1/L2/L3 views
+- **Model validation** → the DSL compiler finds *dangling relations* (references to undefined elements), so inconsistencies surface at build time rather than going undetected in freeform diagrams
+
+Mermaid sequence diagrams complement the C4 model for **specific flow documentation**
+(job execution, workspace creation) where communication order matters.
+
+---
+
+## L1: Software Systems
+
+L1 shows **everything the platform interacts with as a peer**: the platform itself,
+satellite systems we own, and vendors we depend on.
+
+| System | Role |
+|---|---|
+| **Keboola Platform** | The main system — all core services |
+| **Developer Portal** | Satellite — component developer tooling |
+| **Telemetry** | Satellite — built on platform, drives billing |
+
+**Cloud vendors appear at L1 as any other external vendor we depend on** — `aws`,
+`azure`, `gcp`, `snowflake`, alongside Stripe, SendGrid, etc. They are peer systems
+at the context level, and only excluded from L2 (see next slide).
+
+---
+
+## Why Cloud Vendors Are Excluded from L2
+
+Every service depends on whichever cloud the stack runs on. Showing all cloud vendor
+nodes at L2 would clutter every diagram with the same three boxes and obscure the
+actual inter-service relationships.
+
+**Decision:**
+- Cloud vendors appear at **L1** (as any other vendor we depend on — see previous slide)
+- Cloud vendors are **excluded from L2** — "depends on cloud" is true for everything
+- At **L3**, granular vendor services appear (`aws-kms`, `azure-service-bus`, etc.) — but only in the component view of the service that uses them
+
+The same reasoning excludes the **"runs on AKS/EKS/GKE"** relationship:
+every container runs on a managed Kubernetes service — it's true for everything
+and therefore informative for nothing. **Kubernetes is implicit only for the "runs on"
+relationship.** Where Kubernetes is used *differently* — e.g. `queue` using the
+Kubernetes API to spawn job runners — it is modelled explicitly.
+
+---
+
+## Satellite Systems
+
+Not every system we own belongs inside `keboolaPlatform`. A **satellite system** is
+one that is so loosely coupled it doesn't belong to the main system — but it's ours.
+
+How to identify a satellite:
+
+- **Different personas and auth boundaries** — it's used by a distinct audience (component developers, internal ops) rather than by project users
+- **Independent lifecycle** — it can be deployed, versioned, or taken down without affecting the platform
+- **Only integration is at the edges** — it calls the platform like any external client would, or the platform calls it at well-defined touchpoints
+
+Current satellites: **Developer Portal** (component developer tooling, separate auth)
+and **Telemetry** (built on top of the platform, feeds billing).
+
+If a candidate system fails these tests, it probably belongs *inside* `keboolaPlatform`
+as a container, not as a peer system.
+
+---
+
+## L2: Container Decisions
+
+Containers map to independently deployed services or closely related service groups.
+
+Notable grouping decisions:
+
+- **`queue`** — four deployment groups from `job-queue` monorepo + `job-queue-daemon` repo, all in one container because they implement one logical service
+- **`sandboxes`** — covers sandboxes-api, sandboxes-service, apps-proxy, keboola-operator — one product surface
+- **`oauth`** — covers three parallel implementations (JS, PHP, serverless) — same function
+- **`elasticsearch`** — modelled as a container *inside* `keboolaPlatform` because it is self-hosted infrastructure, not an external vendor
+
+---
+
+## L3: Component Rules
+
+- **Every container has components** — even single-Deployment services. Relationships on a container ID only appear at L2; they are invisible on L3.
+- **Every deployed unit is a separate component** — Deployments, CronJobs, Logstash CRDs each get their own component if they serve a distinct role.
+- **Helm hook Jobs are skipped** — `helm.sh/hook: pre-install,pre-upgrade` Jobs (e.g. database migrations) run only during deployment. The core reasoning: this is an **idealized model capturing the settled state** of the platform. Deployment-time mechanisms that get us *to* that state — migrations, schema updates, config seeding — are intentionally omitted. This may prove risky later (future work).
+- **Data-driven templates**: when a Helm template loops over a values list to generate many instances of the same resource, all instances collapse into **one C4 component**, named from the `tags.datadoghq.com/service` label.
+
+---
+
+## Tagging Scheme
+
+Tags drive colours and filtering — not just documentation.
+
+**Language** (one per element):
+`PHP` · `Go` · `Python` · `TypeScript` · `JavaScript` · `Other`
+
+**Status** (when relevant):
+
+| Tag | Meaning | Style |
+|---|---|---|
+| `Legacy` | Predecessor being phased out | Grey, dashed border |
+| `Uncommissioned` | Not yet in production | Amber, dashed border |
+| `SelfHosted` | Self-hosted infrastructure | Dark grey |
+
+**Cloud vendors:** shades of green — dark for aggregated, lighter for granular services.
+
+---
+
+# Tooling
+
+---
+
+## Structurizr DSL
+
+The model is written in [Structurizr DSL](https://structurizr.com/) — plain text that compiles to diagrams.
+
+```
+docker run -it --rm -p 8080:8080 \
+  -v "D:\Work\c4:/usr/local/structurizr" \
+  structurizr/structurizr local
+```
+
+**Why Structurizr?**
+- Plain text → version-controllable, diffable
+- Enforces the C4 metamodel — not freeform boxes
+- Multiple views derived from a single model → relationships stay consistent
+- `!include` lets the model be split into per-service files
+
+---
+
+## File Structure
+
+```
+c4/
+├── workspace.dsl               # Root entry point
+├── model/model.dsl             # Personas, L1 systems, relationships
+├── l2/containers.dsl           # All containers and components
+├── l3/
+│   ├── external-systems.dsl   # Cloud vendor systems
+│   ├── <service>.dsl          # Inter-service relationships
+│   ├── <service>-external.dsl # Cloud vendor relationships
+│   └── <service>.md           # Findings report
+├── views/views.dsl             # All views + styles
+├── skills/                     # Scanning methodology
+└── service-knowledge.md        # Non-detectable service rules
+```
+
+Three files per service keeps things modular — scanning a new service doesn't touch existing files.
+
+---
+
+# Usage
+
+---
+
+## How the Service List Was Constructed
+
+The container inventory was assembled by cross-referencing four sources:
+
+1. **GitHub repositories** — `keboola` org, filtered for actively maintained services
+2. **kbc-stacks** — Helm chart directories under `apps/` reveal what is actually deployed on production stacks
+3. **Infrastructure Terraform modules** — `app-<service>` modules confirm what has production cloud infrastructure
+4. **API documentation** — public Swagger/Apiary docs confirm which repos expose a real service boundary
+
+A service gets a container if it is **independently deployed** and **provides a distinct capability** to the rest of the platform. Repos that are libraries, CLI tools, or build helpers are excluded.
+
+Multi-repo services (e.g. `oauth` has three parallel implementations) are collapsed into
+one container because they serve the same function.
+
+---
+
+## Scanning Approach
+
+Each service is scanned from three sources:
+
+1. **Terraform infra_secrets** — cloud vendor dependencies
+   Scan *all* `.tf` files per cloud variant, not just `main.tf`
+
+2. **kbc-stacks Helm templates** — deployed components
+   Read `values.yaml` too when templates are data-driven
+
+3. **Service source code** — inter-service dependencies
+   PHP: `config/services.yaml` (ServiceClient + class instantiation)
+   Python: source scan required — URLs are sometimes derived programmatically
+
+The methodology is encoded in skills under `c4/skills/`. **Scanning is not
+self-contained** — it is a conversation with the owner of the service. The scanner
+produces a first draft from source; the owner corrects domain-specific nuances the
+scanner cannot infer. A key by-product of every scan is an **update to
+`service-knowledge.md`**, capturing rules that cannot be detected automatically so
+that the next scan of the same service starts from a better baseline.
+
+---
+
+## Scanning Is One-Directional
+
+**Scanning identifies what a service *uses*, not what *calls* the service.**
+
+This is an important consequence of how scanning works — it reads each service's own
+configuration and source code to find outbound dependencies. Inbound callers are
+invisible from within a single service.
+
+This is why the model only becomes consistent **once all services are scanned**:
+- Service A's scan reveals that A calls B
+- That same edge is the answer to "who calls B?" — but it only exists after A has been scanned
+
+Until the full set is covered, the "callers of X" view for any given service is
+necessarily incomplete. This is a deliberate trade-off — per-service scanning keeps
+each scan self-contained and reproducible, at the cost of needing full coverage
+before inbound-dependency questions can be answered reliably.
+
+---
+
+## Shared Infrastructure ≠ Shared Dependency
+
+![Structurizr editor L3 view showing Azure Service Bus appearing as a dependency of both Connection and editor components](editor-sqs-transitive.png)
+
+In this L3-Editor view, **Azure Service Bus** appears connected to both `Session Worker` and `Connection`.
+This is correct at the infrastructure level — but it does not mean they share the same queues.
+
+- `Session Worker` consumes its own **session queue** (`editor_sessions`)
+- `Connection` publishes and consumes entirely different queues (`main`, `commands`, `auditLog`…)
+
+The node is correct. The relationship label is what matters — click the arrow to see which
+queues are actually used. C4 intentionally abstracts away queue-level detail; if queue
+ownership becomes architecturally significant, it belongs in a sequence diagram or ADR.
+
+---
+
+## Sample Conversation with the Scanning Agent
+
+A realistic exchange showing how the model is iteratively refined — the agent does
+a first pass from the source code, the human corrects domain-specific nuances the
+scanner cannot infer:
+
+> **Human:** In `D:\Work\c4\` there is a skill to generate C4 docs for the service `D:\Work\connection\`.
+>
+> **[Agent scans and produces a first-draft DSL]**
+>
+> **Human:** There are more backends than Snowflake. Developer Portal (apps-api) actually refers to the top-level keboola satellite system. There are certainly dependencies to other services — e.g. the queue service. The queue URL originates from `config.template.json` under `keboolaServices.queue`; at runtime it is overridden by `KEBOOLA_SERVICES__QUEUE` and injected into `Storage_Service_StackInfo`. Stripe and SendGrid also have to appear in the System Context.
+>
+> **[Agent updates the DSL]**
+>
+> **Human:** `keboolaServices` is used to populate the index response, but there is *also* an internal `JobQueueClient` dependency to the Queue service API — please triple-check there are no other internal uses of `getService`. Also, only Snowflake and BigQuery are active backends; Supabase is uncommissioned; all others are legacy. `Storage_Service_Jobs` represents "storage jobs", which are a different concept from the "component jobs" provided by the Queue service — please record that distinction in the service knowledge.
+>
+> **Human:** The API container actually serves three distinct APIs:
+> - `connection-storage-api` — callable with a Storage token (project-scoped)
+> - `connection-manage-api` — callable with a Manage token (org-scoped)
+> - `connection-payg-api` — callable by Billing and UI (session/super-scoped)
+>
+> This should be split into three components even though it deploys as one.
+>
+> **[Agent splits the API container and updates service knowledge]**
+>
+> **Human:** Re-read the skill and service knowledge, they were updated too. Now re-iterate the connection DSL — several relationships are missing: `CronJobStorageJobPartitioning` has no edges but at least accesses the databases; token-expiration and CronJob-sync are also unconnected; Stripe is unconnected.
+>
+> **Human:** Worker monitoring is still unconnected — does it really have no dependencies?
+>
+> **Human:** Update the service knowledge to record how these dependencies are extracted.
+
+**Takeaway:** scanning produces a first-draft model; domain expertise refines it.
+Corrections are captured in `service-knowledge.md` so the next scan of the same
+service starts from a better baseline.
+
+---
+
+## Current Status
+
+| Container | Status |
+|---|---|
+| `queue` (job-queue + job-queue-daemon + job-runner) | ✅ Complete |
+| `ai`, `editor`, `sync-actions`, `scheduler` | ✅ Complete |
+| `encryption`, `omnisearch`, `vault` | ✅ Complete |
+| `connection` (storage / manage / payg APIs) | ✅ Complete |
+| `notification`, `billing`, `sandboxes` | 🟡 In progress |
+| `import`, `stream`, `oauth`, `query`, `templates` | 🔲 Not yet scanned |
+| `mcp-server`, `kai-assistant` | 🔲 Not yet scanned |
+| `cli`, `ui`, `api` | 🔲 Not yet scanned |
+| `metastore`, `skill-registry` | ⚠️ Uncommissioned |
+| `elasticsearch` | — Not applicable |
+
+---
+
+## Future Work
+
+- **Finish scanning** — complete coverage across all remaining containers so inbound-dependency views become reliable
+- **Tackle shared resources** — KMS keys, queues, databases: decide how to model ownership vs. access vs. transitive sharing
+- **Decide open questions** — e.g. DB grouping: one component per DB, or grouped by service? Component granularity for multi-tenant stores?
+- **Check, check, check** — cross-validate the model against reality; hunt for dangling relations, missed dependencies, outdated edges
+- **Core feature views** — sequence diagrams for key end-to-end flows (job execution, table import with triggers, workspace creation)
+- **Update pipeline** — automate model drift detection: re-scan services on schedule or on PR, flag diffs for review
+- **ADRs** — start capturing architectural decisions alongside the model so the *why* is preserved, not just the *what*

--- a/plugins/developer/skills/keboola-architecture/references/c4/README.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/README.md
@@ -1,0 +1,13 @@
+# C4 Architecture Model
+
+C4 diagrams for the Keboola platform, authored in [Structurizr DSL](https://structurizr.com/dsl).
+
+## Viewing the diagrams
+
+Run Structurizr locally via Docker:
+
+```
+docker run -it --rm -p 8080:8080 -v "/path/to/c4:/usr/local/structurizr" structurizr/structurizr local
+```
+
+Then open http://localhost:8080 in your browser.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l2/containers.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l2/containers.dsl
@@ -1,0 +1,589 @@
+    # -------------------------------------------------------------------------
+    # Keboola Platform — L2 Containers
+    # -------------------------------------------------------------------------
+
+    # --- Core / Monolith ---
+
+    connection = container "Connection" "Core platform monolith. Three APIs (Storage, Manage, PAYG) plus background workers. Manages projects, tokens, storage backends, configurations, events." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/connection"
+        properties {
+            "repos" "connection"
+        }
+
+        connection-storage-api = component "Storage API" "Zend-based REST API (/v1, /v2). Core data-plane: buckets, tables, files, tokens, events, workspaces, dev branches." "PHP" {
+            tags "PHP"
+        }
+        connection-manage-api = component "Manage API" "Zend-based REST API (/manage). Org-level: projects, users, storage backends, maintainers." "PHP" {
+            tags "PHP"
+        }
+        connection-payg-api = component "PAYG API" "Zend-based REST API (/pay-as-you-go). Pay-as-you-go billing: Stripe payments, credits, registration wizard." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-main = component "Worker: main" "Processes storage jobs from the main queue." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-commands = component "Worker: commands" "Processes CLI command messages (e.g. project purge)." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-audit-log = component "Worker: audit-log" "Writes audit log entries from the internal audit-log queue." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-events-elastic = component "Worker: events-elastic" "Reads events and indexes them into Elasticsearch." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-search-index = component "Worker: search-index" "Reads data and updates the global search index." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-triggers = component "Worker: triggers" "Consumes table trigger events and fires component jobs via Queue." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-user-tasks-scheduler = component "Worker: user-tasks-scheduler" "Reads ScheduledTask entities from MySQL and enqueues storage jobs at cron-expression times." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-monitoring = component "Worker: monitoring" "Tests live connections to customer Snowflake and BigQuery backends." "PHP" {
+            tags "PHP"
+        }
+        connection-worker-certificate-rotation = component "Worker: certificate-rotation" "Reads/writes certificate records in MySQL, executes DDL on Snowflake, sends expiry warning emails." "PHP" {
+            tags "PHP"
+        }
+        connection-publish-worker-metrics = component "Worker: publish-worker-metrics" "Publishes worker metrics." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-token-expiration = component "CronJob: token-expiration" "Deletes expired storage/manage tokens, invitations, sessions, and project-admin associations." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-project-purge-scheduler = component "CronJob: project-purge-scheduler" "Reads deleted projects and enqueues project-purge commands." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-sync-apps = component "CronJob: sync-apps" "Syncs UI app definitions from the reference Connection stack into the local database." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-sync-components = component "CronJob: sync-components" "Fetches component definitions from Developer Portal and writes them to the apis table." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-storage-jobs-table-partitioning = component "CronJob: storage-jobs-partitioning" "Manages bi_storage_jobs MySQL range partitions." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-global-search-table-partitioning = component "CronJob: global-search-partitioning" "Manages bi_gs_consistency MySQL range partitions." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-add-audit-log-partition = component "CronJob: audit-log-partition" "Manages bi_auditLog MySQL range partitions." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-snapshot-project-metrics = component "CronJob: snapshot-project-metrics" "Snapshots per-project metrics." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-workers-expiration = component "CronJob: workers-expiration" "Expires stale workers." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-clear-expired-oauth-tokens = component "CronJob: clear-expired-oauth-tokens" "Clears expired OAuth 2 server tokens." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-release-staled-locks = component "CronJob: release-staled-locks" "Lists pods via Kubernetes API to release stale distributed locks." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-delete-events-indices = component "CronJob: delete-events-indices" "Monthly. Deletes old Elasticsearch events indices." "PHP" {
+            tags "PHP"
+        }
+        connection-cronjob-roll-elastic-events-index = component "CronJob: roll-elastic-events-index" "Monthly. Rolls the active Elasticsearch events index." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- AI / ML ---
+
+    ai = container "AI Service" "Handles AI-powered features: LLM responses, vector index management, prompt/feedback recording." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/ai-service"
+        properties {
+            "repos" "ai-service"
+        }
+
+        ai-api = component "AI API" "PHP REST API handling AI feature requests." "PHP" {
+            tags "PHP"
+        }
+        ai-agent = component "KAI Bot Agent" "Python sidecar providing LLM agent capabilities. Communicates with AI API on localhost." "Python" {
+            tags "Python"
+        }
+        ai-index-builder = component "AI Index Builder" "Daily CronJob. Runs Python agent to rebuild vector index from project data in Connection." "Python" {
+            tags "Python"
+        }
+    }
+
+    # --- Editor (SQL Editor / Workspace UI backend) ---
+
+    editor = container "Editor" "Backend for the SQL Editor and persistent Workspace management. Handles workspace lifecycle, query execution, and notebook management." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/editor-service"
+        properties {
+            "repos" "editor-service"
+        }
+
+        editor-api = component "Editor API" "Symfony REST API. Manages workspace sessions, SQL queries, notebooks." "PHP" {
+            tags "PHP"
+        }
+        editor-consumer = component "Editor Consumer" "Symfony Messenger consumer (two instances). Subscribes to connection-events and connection-audit-log topics from Connection." "PHP" {
+            tags "PHP"
+        }
+        editor-session-worker = component "Editor Session Worker" "Symfony Messenger consumer. Polls workspace jobs and manages workspace session lifecycle." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Sync Actions (runner-sync-api) ---
+
+    sync-actions = container "Sync Actions" "Executes component sync actions (e.g. test connection, get buckets). Short-lived synchronous job execution." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/runner-sync-api"
+        properties {
+            "repos" "runner-sync-api"
+        }
+
+        sync-actions-api = component "Sync Actions API" "REST API. Accepts sync action requests, spawns ephemeral containers via Kubernetes, returns results." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Scheduler ---
+
+    scheduler = container "Scheduler" "Manages scheduled component job execution. Triggers jobs based on cron schedules or event rules." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/scheduler"
+        properties {
+            "repos" "scheduler"
+        }
+
+        scheduler-api = component "Scheduler API" "Symfony REST API. Manages schedule definitions." "PHP" {
+            tags "PHP"
+        }
+        scheduler-cron = component "Scheduler CronJob" "Runs every minute. Evaluates due schedules and enqueues component jobs via Queue API." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Queue ---
+
+    queue = container "Queue" "Manages component job lifecycle (create, run, monitor, complete). Includes public API, internal API, daemon, and ephemeral job runner." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/job-queue"
+        properties {
+            "repos" "job-queue, job-queue-daemon, job-runner"
+        }
+
+        queue-public-api = component "Queue Public API" "REST API for creating and querying component jobs." "PHP" {
+            tags "PHP"
+        }
+        queue-internal-api = component "Queue Internal API" "Internal REST API used by daemon to update job state." "PHP" {
+            tags "PHP"
+        }
+        queue-logstash = component "Queue Logstash" "Ships job records from MySQL to Elasticsearch for search." "Other" {
+            tags "Other"
+        }
+        queue-cleanup = component "CronJob: cleanup" "Every 12h. Deletes job records for purged projects." "PHP" {
+            tags "PHP"
+        }
+        queue-purge = component "CronJob: purge" "Every 3h. Purges old job records." "PHP" {
+            tags "PHP"
+        }
+        queue-replication-check = component "CronJob: replication-check" "Every 15min. Verifies MySQL-to-Elasticsearch replication lag." "PHP" {
+            tags "PHP"
+        }
+        queue-runner = component "Job Runner (service-container)" "Ephemeral per-job pod. Executes a single component job. Spawned by daemon, exits on completion." "PHP" {
+            tags "PHP"
+        }
+        queue-gelf-logger = component "GELF Logger" "GELF log collector sidecar. Ships job logs to Connection Storage." "Other" {
+            tags "Other"
+        }
+        queue-job-runner = component "Job Runner (legacy)" "Legacy monolithic job runner. Being replaced by service-container split." "PHP" {
+            tags "PHP" "Legacy"
+        }
+        queue-daemon-run = component "Daemon: run" "Main daemon loop. Polls for new jobs, spawns runner pods via Kubernetes API." "PHP" {
+            tags "PHP"
+        }
+        queue-daemon-start = component "Daemon: start" "Processes jobs-to-start messages. Handles job startup after pod is ready." "PHP" {
+            tags "PHP"
+        }
+        queue-daemon-stop = component "Daemon: stop" "Handles graceful job stopping." "PHP" {
+            tags "PHP"
+        }
+        queue-daemon-flow-transition = component "Daemon: flow-transition" "Processes flow job state transitions." "PHP" {
+            tags "PHP"
+        }
+        daemon-cron-pod-cleanup = component "Daemon CronJob: pod-cleanup" "Every 10min. Cleans up orphaned K8s pods via Kubernetes API." "PHP" {
+            tags "PHP"
+        }
+        daemon-cron-db-cleanup = component "Daemon CronJob: db-cleanup" "Every hour. Cleans up stale DB records via internal API." "PHP" {
+            tags "PHP"
+        }
+        daemon-cron-flow-cleanup = component "Daemon CronJob: flow-cleanup" "Every 30min. Removes stale flow job data via internal API." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Encryption ---
+
+    encryption = container "Encryption" "Encrypts and decrypts configuration secrets using per-component KMS keys." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/encryption-api"
+        properties {
+            "repos" "encryption-api"
+        }
+
+        encryption-api = component "Encryption API" "REST API. Wraps Keboola ObjectEncryptor. Encrypts/decrypts arbitrary values using the shared job-runner KMS key." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Omnisearch (serves at metastore.{suffix}) ---
+
+    omnisearch = container "Omnisearch" "Provides platform-wide search across configurations, transformations, and metadata. Serves at metastore.{suffix}." "Python" {
+        tags "Python"
+        url "https://github.com/keboola/omnisearch-and-metadata-engine"
+        properties {
+            "repos" "omnisearch-and-metadata-engine"
+        }
+
+        omnisearch-service-api = component "Omnisearch API" "REST API. Queries the metastore index for configurations and transformations." "Python" {
+            tags "Python"
+        }
+        omnisearch-metastore-builder = component "Metastore Builder" "Background worker. Builds and updates the metastore index from Storage and Queue data." "Python" {
+            tags "Python"
+        }
+    }
+
+    # --- Vault ---
+
+    vault = container "Vault" "Stores and manages shared variables and secrets (user-defined key-value pairs accessible across jobs)." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/vault"
+        properties {
+            "repos" "vault"
+        }
+
+        vault-api = component "Vault API" "Symfony REST API. CRUD for variables. Records audit events to Connection." "PHP" {
+            tags "PHP"
+        }
+        vault-messenger-consumer-connection-events = component "Connection Events Consumer" "Symfony Messenger consumer. Receives devBranchDeleted events and purges associated branch variables." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Billing ---
+
+    billing = container "Billing" "Tracks per-project resource usage and calculates credits consumed. Integrates with cloud marketplaces for PAYG billing." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/billing-api"
+        properties {
+            "repos" "billing-api"
+        }
+
+        billing-api = component "Billing API" "Symfony REST API. Exposes usage and billing data, processes marketplace webhooks." "PHP" {
+            tags "PHP"
+        }
+        billing-gcp-marketplace-consumer = component "GCP Marketplace Consumer" "Deployment (GCP stacks only). Processes Google Cloud Marketplace entitlement and account events via Pub/Sub." "PHP" {
+            tags "PHP"
+        }
+        billing-marketplaces-reporting-azure = component "Azure Marketplace Reporter" "CronJob (Azure stacks only, every 20min). Reports hourly usage batches to Azure Marketplace Metering Service." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Notification ---
+
+    notification = container "Notification" "Sends user notifications (email, webhooks) for job completions, errors, and platform events." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/notification-service"
+        properties {
+            "repos" "notification-service"
+        }
+
+        notification-api = component "Notification API" "Symfony REST API. Accepts events, manages subscriptions, publishes onto internal queue." "PHP" {
+            tags "PHP"
+        }
+        notification-messenger-consumer = component "Notification Consumer" "Symfony Messenger consumer. Matches events to subscriptions, delivers via SendGrid or webhook." "PHP" {
+            tags "PHP"
+        }
+        notification-expired-subscription-pruning = component "CronJob: expired-subscription-pruning" "Every 10min. Soft-deletes expired project subscriptions." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- Import (sapi-importer) ---
+
+    import = container "Import" "Handles large file imports into Keboola Storage. Manages sliced file uploads and table import orchestration." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/sapi-importer"
+        properties {
+            "repos" "sapi-importer"
+        }
+
+        sapi-importer-api = component "Import API" "REST API. Accepts file upload requests and imports them into Storage via the Storage API." "PHP" {
+            tags "PHP"
+        }
+    }
+
+    # --- OAuth ---
+
+    oauth = container "OAuth" "Manages OAuth 2.0 credentials for third-party integrations. Stores and retrieves encrypted OAuth tokens on behalf of components." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/oauth-service"
+        properties {
+            "repos" "oauth-api, oauth-service, oauth-api-serverless"
+        }
+
+        oauth-service-api = component "OAuth API" "Symfony REST API. CRUD for OAuth credentials. Verifies tokens via Storage API." "PHP" {
+            tags "PHP"
+        }
+        oauth-service-messenger-consumer-connection-events = component "Connection Events Consumer" "Symfony Messenger consumer. Receives devBranchDeleted events and purges associated OAuth sessions." "PHP" {
+            tags "PHP"
+        }
+        oauth-service-session-expiration = component "CronJob: session-expiration" "Every 15min. Soft-expires old authentication sessions." "PHP" {
+            tags "PHP"
+        }
+        oauth-serverless-proxy = component "Serverless Proxy" "Nginx sidecar routing requests to the legacy serverless OAuth implementation during transition." "Other" {
+            tags "Other" "Legacy"
+        }
+    }
+
+    # --- MCP Server ---
+
+    mcp-server = container "MCP Server" "Model Context Protocol server. Exposes Keboola platform capabilities to AI agents (Cursor, Claude, Windsurf) and internally to kai-assistant." "Python" {
+        tags "Python"
+        url "https://github.com/keboola/mcp-server"
+        properties {
+            "repos" "mcp-server"
+        }
+
+        mcp-server-api = component "MCP Server" "Hosted MCP server (http-compat transport). Serves external AI agents via OAuth." "Python" {
+            tags "Python"
+        }
+        mcp-server-agent = component "MCP Server Agent" "Internal MCP server (streamable-http transport). Serves kai-assistant. No OAuth -- caller passes Storage token directly." "Python" {
+            tags "Python"
+        }
+    }
+
+    # --- Templates ---
+
+    templates = container "Templates" "Manages reusable pipeline templates. Reads template definitions from GitHub at runtime and applies them to create configurations in Keboola Storage." "Go" {
+        tags "Go"
+        url "https://github.com/keboola/keboola-as-code"
+        properties {
+            "repos" "keboola-as-code"
+        }
+
+        templates-api = component "Templates API" "Go REST API. Applies templates to create/update Keboola configurations. Reads template definitions from GitHub." "Go" {
+            tags "Go"
+        }
+        templates-api-etcd = component "etcd" "Self-hosted etcd cluster (Bitnami sub-chart, 3 replicas). Provides write atomicity locking for template operations. Separate instance from stream-etcd." "Other" {
+            tags "SelfHosted" "Other"
+        }
+    }
+
+    # --- Stream ---
+
+    stream = container "Stream" "Ingests small and frequent events into project storage." "Go" {
+        tags "Go"
+        url "https://github.com/keboola/keboola-as-code"
+        properties {
+            "repos" "keboola-as-code"
+        }
+
+        stream-api = component "Stream API" "Go REST API. Manages stream definitions (sources, sinks). Authenticates via Storage API." "Go" {
+            tags "Go"
+        }
+        stream-http-source = component "HTTP Source" "High-throughput HTTP ingest endpoint. Accepts incoming data records from external producers." "Go" {
+            tags "Go"
+        }
+        stream-storage-coordinator = component "Storage Coordinator" "Orchestrates the lifecycle of slices and files -- triggers uploads and imports into Keboola Storage." "Go" {
+            tags "Go"
+        }
+        stream-storage-writer = component "Storage Writer" "Receives encoded data from http-source nodes over TCP/KCP, buffers to local disk volumes." "Go" {
+            tags "Go"
+        }
+        stream-storage-reader = component "Storage Reader" "Reads locally buffered data and uploads to staging, then triggers import into Keboola Storage. Co-located with writer in one StatefulSet pod." "Go" {
+            tags "Go"
+        }
+        stream-etcd = component "etcd" "Self-hosted etcd cluster (Bitnami sub-chart). Distributed coordination, cluster state machine, task locking, statistics sync. Separate instance from templates-api-etcd." "Other" {
+            tags "SelfHosted" "Other"
+        }
+    }
+
+    # --- KAI Assistant (three apps: ai-chat, kai-assistant, kai-agent) ---
+
+    kai-assistant = container "KAI Assistant" "Three AI chat apps sharing the same Terraform module: ai-chat (read-only chat), kai-assistant (BFF backend), and kai-agent (agentic code executor). All call Connection, mcp-server-agent, and a cloud LLM (Vertex AI or Azure AI Foundry)." "TypeScript" {
+        tags "TypeScript"
+        url "https://github.com/keboola/ui"
+        properties {
+            "repos" "ai-chat, ui"
+        }
+
+        kai-app-ai-chat = component "AI Chat" "Next.js read-only chat app. Uses OAuth for authentication. Repo: keboola/ai-chat." "TypeScript" {
+            tags "TypeScript"
+        }
+        kai-app-kai-assistant = component "KAI Assistant" "Next.js BFF backend for the KAI Assistant chat UI. Repo: keboola/ui (apps/kai-assistant-backend)." "TypeScript" {
+            tags "TypeScript"
+        }
+        kai-app-kai-agent = component "KAI Agent" "Hono HTTP server. Agentic executor with sandboxed code execution via E2B. Repo: keboola/ui (apps/kai-agent)." "TypeScript" {
+            tags "TypeScript"
+        }
+    }
+
+    # --- API Portal ---
+
+    api = container "API Portal" "Static React SPA serving OpenAPI documentation for all platform services. No runtime service dependencies -- specs are fetched from live services at build time and bundled as static files." "TypeScript" {
+        tags "TypeScript"
+        url "https://github.com/keboola/api-service"
+        properties {
+            "repos" "api-service"
+        }
+
+        api-portal = component "API Portal" "Vite/React SPA using RapiDoc. Serves pre-built OpenAPI specs for all platform services. Stack-aware: filters available services per hostname via config.json." "TypeScript" {
+            tags "TypeScript"
+        }
+    }
+
+    # --- Query ---
+
+    query = container "Query" "Handles SQL query execution against Keboola Storage backends (Snowflake, BigQuery). Used by SQL Editor and other consumers." "Go" {
+        tags "Go"
+        url "https://github.com/keboola/go-monorepo"
+        properties {
+            "repos" "go-monorepo"
+        }
+
+        query-service-api = component "Query API" "Go REST API. Accepts query requests, creates jobs, returns results. Serves at query.{suffix}." "Go" {
+            tags "Go"
+        }
+        query-service-coordinator = component "Query Coordinator" "Distributes jobs to workers, monitors worker heartbeats, manages session lifecycle." "Go" {
+            tags "Go"
+        }
+        query-service-worker = component "Query Worker" "Executes SQL queries against Snowflake or BigQuery. Polls job queues from PostgreSQL." "Go" {
+            tags "Go"
+        }
+        query-service-partition-maintenance = component "CronJob: partition-maintenance" "Daily. Manages PostgreSQL table partitions for job history tables." "Go" {
+            tags "Go"
+        }
+    }
+
+    # --- Sandboxes / Workspaces / Data Apps ---
+
+    sandboxes = container "Sandboxes" "Manages Python/R Workspaces and Data Apps (Apps). Four sub-systems: sandboxes-service (PHP REST API), apps-proxy (Go reverse proxy for Apps), keboola-operator (Go K8s operator), and sandboxes component (ephemeral PHP job run via job-queue)." "PHP" {
+        tags "PHP"
+        url "https://github.com/keboola/sandboxes-service"
+        properties {
+            "repos" "sandboxes-service, keboola-as-code, keboola-operator, sandboxes"
+        }
+
+        sandboxes-service-api = component "Sandboxes Service API" "PHP/Symfony REST API (RoadRunner). Central API for Workspace and App lifecycle. Serves at data-science.{suffix}. Manages provisioning strategy selection (operator vs job-queue vs E2B)." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-garbage-collector = component "CronJob: garbage-collector" "Every 15min. Cleans up orphaned K8s pods, PVCs, and persistent storages." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-messenger-consumer-connection-events = component "Messenger Consumer: connection-events" "Symfony Messenger consumer. Receives project and workspace lifecycle events from Connection (Pattern B)." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-messenger-consumer-connection-audit-log = component "Messenger Consumer: connection-audit-log" "Symfony Messenger consumer. Receives audit log events from Connection (Pattern B)." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-sync-app-runs-watch = component "Sync App Runs Watch" "Deployment. Watches K8s AppRun CRDs and syncs their state back to the sandboxes-service database." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-suspend = component "CronJob: suspend" "Suspends idle sandboxes on schedule." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-purge-app-runs = component "CronJob: purge-app-runs" "Purges old app run records." "PHP" {
+            tags "PHP"
+        }
+        sandboxes-service-prune-app-run-logs = component "CronJob: prune-app-run-logs" "Prunes old app run log entries." "PHP" {
+            tags "PHP"
+        }
+        apps-proxy = component "Apps Proxy" "Go reverse proxy (keboola-as-code cmd/apps-proxy). Routes HTTP requests to App pods in K8s. Authenticates via sandboxes-service. Used for Apps only, not Sandboxes." "Go" {
+            tags "Go"
+        }
+        keboola-operator = component "Keboola Operator" "Go Kubernetes operator (keboola-operator repo). Manages App, StorageToken, E2bSandbox CRDs. Standard provisioning path for Apps; phasing in for Sandboxes. Decrypts app configs using job-runner KMS key." "Go" {
+            tags "Go"
+        }
+        sandboxes-component = component "Sandboxes Component" "Ephemeral PHP job pod run via job-queue (keboola/sandboxes repo, component ID: keboola.sandboxes). Standard provisioning path for Workspaces; legacy path for Apps. Directly manages K8s resources. Being phased out for Apps." "PHP" {
+            tags "PHP" "Legacy"
+        }
+    }
+
+    # --- CLI / UI ---
+
+    cli = container "CLI" "Keboola CLI tool. Interacts with platform APIs for local development workflows." "Go" {
+        tags "Go"
+        url "https://github.com/keboola/keboola-as-code"
+        properties {
+            "repos" "keboola-as-code"
+        }
+    }
+
+    ui = container "UI" "Keboola web application. Provides the main user interface for the platform." "JavaScript" {
+        tags "JavaScript"
+        url "https://github.com/keboola/kbc-ui"
+        properties {
+            "repos" "kbc-ui"
+        }
+    }
+
+    # --- Shared infrastructure ---
+
+    connection-elasticsearch = container "Connection Elasticsearch" "Self-hosted Elasticsearch cluster for Connection. Event search, global search index, audit log indexing. Namespace: connection-elasticsearch." "Other" {
+        tags "SelfHosted" "Other"
+    }
+
+    job-queue-elasticsearch = container "Queue Elasticsearch" "Self-hosted Elasticsearch cluster for Queue. Job indexing and search. Separate instance, separate version from Connection Elasticsearch." "Other" {
+        tags "SelfHosted" "Other"
+    }
+
+    # --- Uncommissioned / future containers ---
+
+    git-service = container "Git Service" "Internal REST API wrapping the self-hosted Forgejo instance. Manages Git repositories on behalf of platform services." "Go" {
+        tags "Go" "Uncommissioned"
+        url "https://github.com/keboola/go-monorepo"
+        properties {
+            "repos" "go-monorepo"
+        }
+
+        git-service-api = component "Git Service API" "Go REST API. Wraps Forgejo admin API for repository management. Authenticates callers via Connection Manage API." "Go" {
+            tags "Go"
+        }
+    }
+
+    forgejo = container "Forgejo" "Self-hosted Git service. Stores and serves Git repositories for the platform. Deployed via upstream Bitnami/Forgejo Helm chart." "Other" {
+        tags "SelfHosted" "Other" "Uncommissioned"
+    }
+
+    nats = container "NATS" "Planned NATS message broker. kbc-stacks chart exists but has no templates and no consumers. Not yet commissioned." "Other" {
+        tags "Other" "Uncommissioned"
+    }
+
+    metastore = container "Metastore" "Stores and serves metadata objects and references for the platform. Implemented; gated on metastore_enabled in stack variables." "Go" {
+        tags "Go" "Uncommissioned"
+        url "https://github.com/keboola/go-monorepo"
+        properties {
+            "repos" "go-monorepo"
+        }
+
+        metastore-api = component "Metastore API" "Go REST API. Stores and queries metadata objects. Verifies tokens via Connection." "Go" {
+            tags "Go"
+        }
+    }
+
+    skill-registry = container "Skill Registry API" "PHP/Symfony REST API and React frontend for registering and executing agentic skills. Own authentication (X-API-TOKEN), OAuth broker for GitHub/Google/HubSpot/Slack/Salesforce. Deployed on canary-orion via its own Helm chart -- not in kbc-stacks and not on production stacks." "PHP" {
+        tags "PHP" "Uncommissioned"
+        url "https://github.com/keboola/skill-registry-api"
+        properties {
+            "repos" "skill-registry-api"
+        }
+    }
+
+    skill-registry-mcp-server = container "Skill Registry MCP Server" "Python MCP server. Connects to the Skill Registry API and exposes registered skills as MCP tools. kbc-stacks chart exists but has no templates." "Python" {
+        tags "Python" "Uncommissioned"
+        url "https://github.com/keboola/skill-registry-mcp-server"
+        properties {
+            "repos" "skill-registry-mcp-server"
+        }
+    }

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service-external.dsl
@@ -1,0 +1,16 @@
+# Cloud resource relationships for ai-service
+# Included at top level of model block in model.dsl
+
+ai-api           -> azure-openai-ai-service      "generates LLM responses and embeddings"
+ai-api           -> mysql-instance-job-queue      "persists application data (shares job-queue MySQL instance)"
+ai-api           -> kms-key-ai-aws               "encrypts data at rest on AWS stacks"
+ai-api           -> kms-key-ai-azure             "encrypts data at rest on Azure stacks"
+ai-api           -> kms-key-ai-gcp              "encrypts data at rest on GCP stacks"
+ai-api           -> storage-ai-vectorstore-aws    "stores and reads vector index on AWS stacks"
+ai-api           -> storage-ai-vectorstore-azure  "stores and reads vector index on Azure stacks"
+ai-api           -> storage-ai-vectorstore-gcp    "stores and reads vector index on GCP stacks"
+
+ai-index-builder -> azure-openai-ai-service      "generates embeddings for vector index rebuild"
+ai-index-builder -> storage-ai-vectorstore-aws    "writes rebuilt vector index on AWS stacks"
+ai-index-builder -> storage-ai-vectorstore-azure  "writes rebuilt vector index on Azure stacks"
+ai-index-builder -> storage-ai-vectorstore-gcp    "writes rebuilt vector index on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service.dsl
@@ -1,0 +1,8 @@
+# L3 inter-service relationships for ai-service
+# Included inside keboolaPlatform block in model.dsl
+
+ai-api           -> connection "reads/writes storage, verifies tokens via Storage API and Manage API"
+ai-api           -> queue      "submits component jobs"
+ai-api           -> stream     "records prompts and feedback (PROMPT_RECORD_URL / FEEDBACK_RECORD_URL)"
+ai-agent         -> ai-api     "calls for context and responses via localhost"
+ai-index-builder -> connection "reads project data and configurations to build vector index"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/ai-service.md
@@ -1,0 +1,19 @@
+# ai-service — dependency analysis
+
+## Deployed components
+- `ai-api` (Deployment): containers `app` (PHP API) + `agent` (Python kai-bot sidecar, localhost:8181 only)
+- `ai-index-builder` (CronJob, daily at 05:20): container `agent` (Python, runs shared builder script)
+
+## Inter-service dependencies
+- `ai-api` -> `connection`: `getConnectionServiceUrl` via `Keboola\ManageApi\Client` and `Keboola\StorageApiBranch\Factory\ClientOptions` in services.yaml
+- `ai-api` -> `queue`: `getQueueUrl` via `App\JobQueueClientFactory` in services.yaml
+- `ai-api` -> `stream`: `PROMPT_RECORD_URL`, `FEEDBACK_RECORD_URL` injected via appSecrets (confirmed in service-knowledge.md)
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `azure-openai-ai-service` | Azure OpenAI | omnisearch | `AZURE_OPENAI_ENDPOINT`, `AZURE_LLM_DEPLOYMENT`, `AZURE_EMBEDS` — present in all three cloud variants; `module.azure_openai[0]` in app_ai_service.tf |
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, vault, notification, billing | `mysql_config = local.job_queue_mysql_config` in app_ai_service.tf |
+
+## Unresolved
+None.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service-external.dsl
@@ -1,0 +1,5 @@
+# Cloud resource relationships for api-service
+# Included at top level of model block in model.dsl
+#
+# No cloud resource relationships — the API Portal is a static SPA with
+# no runtime dependencies on databases, queues, object storage, or KMS keys.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service.dsl
@@ -1,0 +1,7 @@
+# L3 inter-service relationships for api-service
+# Included inside keboolaPlatform block in model.dsl
+#
+# The API Portal has NO runtime inter-service dependencies.
+# It is a fully static SPA — OpenAPI specs are fetched from live services
+# at Docker image build time (collector/collect.js) and bundled as static files.
+# There are no server-side API calls at runtime.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/api-service.md
@@ -1,0 +1,37 @@
+# api-service — dependency analysis
+
+## Deployed components
+
+- `api-portal` (Deployment): Static React SPA (Vite build) serving OpenAPI documentation
+  for all platform services. Rendered in the browser using RapiDoc. Hosted at
+  `api.{suffix}`. Single replica, no health dependencies.
+
+## Inter-service dependencies
+
+**None at runtime.** The API Portal is a fully static SPA. All content is pre-built
+into the Docker image at CI time.
+
+## Build-time collector (not a runtime dependency)
+
+The `collector/collect.js` script runs as `npm run collect` during the Docker image build.
+It fetches OpenAPI spec files from live service endpoints (defined in `src/config.json`
+as `openApiUrl`) and writes them to `public/specs/`. These become static assets bundled
+into the image. The collector calls one reference stack (north-europe.azure.keboola.com
+or us-east4.gcp.keboola.com) per service — these are **build-time** HTTP calls, not
+runtime dependencies.
+
+Services with specs collected (from config.json): ai, billing, editor, encryption,
+import, job-queue, manage, notification, oauth, query, sandboxes-service, scheduler,
+stream, sync-actions, templates, vault. Storage API has no openApiUrl (skipped).
+
+## Named cloud resource dependencies
+
+None.
+
+## Notes
+
+- No Terraform module, no infra secrets, no database.
+- Stack filtering is client-side: `config.json` maps hostnames to excluded services,
+  and the browser filters the service selector dropdown accordingly.
+- The `storage` service entry has an empty `openApiUrl` and is skipped by the collector.
+  Its docs are not served by the portal.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api-external.dsl
@@ -1,0 +1,13 @@
+# Cloud resource relationships for billing-api
+# Included at top level of model block in model.dsl
+# Note: billing-api has no AWS module — it runs on Azure and GCP stacks only.
+
+billing-api                          -> mysql-instance-job-queue "persists billing data (shares job-queue MySQL instance)"
+billing-api                          -> azure-marketplace        "resolves and activates marketplace subscriptions on Azure stacks"
+billing-api                          -> google-marketplace       "resolves entitlements via Cloud Commerce Partner Procurement API on GCP stacks"
+
+billing-gcp-marketplace-consumer     -> mysql-instance-job-queue "persists billing data"
+billing-gcp-marketplace-consumer     -> google-marketplace       "processes entitlement and account events via Pub/Sub subscription on Google's marketplace topic"
+
+billing-marketplaces-reporting-azure -> mysql-instance-job-queue "reads subscription data to report"
+billing-marketplaces-reporting-azure -> azure-marketplace        "reports hourly usage batches via Metering Service API"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api.dsl
@@ -1,0 +1,7 @@
+# L3 inter-service relationships for billing-api
+# Included inside keboolaPlatform block in model.dsl
+
+billing-api                          -> connection "verifies tokens and reads project/org data via Storage and Manage APIs"
+billing-api                          -> queue      "triggers jobs via Queue API (resolved via Storage API service URL)"
+billing-gcp-marketplace-consumer     -> connection "verifies tokens"
+billing-marketplaces-reporting-azure -> connection "reads subscriptions and billing data"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/billing-api.md
@@ -1,0 +1,27 @@
+# billing-api — dependency analysis
+
+## Deployed components
+- `billing-api` (Deployment): PHP Symfony REST API — credits, PAYG top-up, marketplace webhooks
+- `billing-gcp-marketplace-consumer` (Deployment, GCP stacks only): command `messenger:consume google_marketplace_events` — processes Google Cloud Marketplace entitlement and account events via Pub/Sub subscription on Google's marketplace topic (`projects/cloudcommerceproc-prod/topics/keboola-marketplace`)
+- `billing-marketplaces-reporting-azure` (CronJob, Azure stacks only, every 20 min): command `app:marketplaces:report-usage azure` — reports hourly usage batches to Azure Marketplace Metering Service
+
+## Inter-service dependencies
+- `billing-api` -> `connection`: `Keboola\StorageApiBranch\Factory\ClientOptions` + `App\Factory\ManageApiClientFactory` using `STORAGE_API_URL` in services.yaml; `App\Credits\PayAsYouGoClient` also calls Connection's PAYG API with `APPLICATION_TOKEN`
+- `billing-api` -> `queue`: `App\Factory\QueueApiClientFactory` calls `storageApiClient->getServiceUrl('queue')` — URL resolved dynamically via Storage API, not from ENV
+- `billing-gcp-marketplace-consumer` -> `connection`: token verification
+- `billing-marketplaces-reporting-azure` -> `connection`: reads subscription and billing data
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, vault, notification, ai | `mysql_config = local.job_queue_mysql_config` in app_billing_api.tf (Azure + GCP) |
+| `azure-marketplace` | SaaS | — | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` in azure/infra_secrets.tf; `Keboola\AzureApiClient\Marketplace\MarketplaceApiClient` and `MeteringServiceApiClient` in services.yaml |
+| `google-marketplace` | SaaS | — | `GOOGLE_MARKETPLACE_EVENTS_QUEUE_DSN` subscribing to `projects/cloudcommerceproc-prod/topics/keboola-marketplace`; `App\Marketplace\GoogleCloud\ApiClient\ProcurementApiClientFactory` in services.yaml |
+
+## Unresolved
+None.
+
+## Notes
+- No AWS module exists for billing-api — it runs on Azure and GCP stacks only. No AWS KMS, no AWS MySQL.
+- Queue URL is resolved dynamically via `storageApiClient->getServiceUrl('queue')` — not injected as a dedicated ENV key, so invisible to ENV-only scanning.
+- The GCP Pub/Sub subscription subscribes to Google's own marketplace topic (`projects/cloudcommerceproc-prod/...`), not a Keboola-owned resource. Modelled via `google-marketplace`, not as a named cloud resource instance.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/cloud-resources.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/cloud-resources.dsl
@@ -1,0 +1,385 @@
+    # -------------------------------------------------------------------------
+    # Named Cloud Resource Instances
+    # -------------------------------------------------------------------------
+
+    # --- MySQL instances ---
+
+    mysql-instance-connection = softwareSystem "MySQL: connection" "Dedicated MySQL instance hosting only the Connection database. CFn: kbc-connection-rds." {
+        tags "CloudResource" "MySQL"
+    }
+    mysql-instance-job-queue = softwareSystem "MySQL: job-queue" "Shared MySQL instance hosting databases for: job-queue, editor, scheduler, vault, notification, ai, billing, oauth. CFn: kbc-job-queue-rds." {
+        tags "CloudResource" "MySQL"
+    }
+
+    # --- Shared KMS / Key Vault keys (job-runner) ---
+
+    kms-key-job-runner-aws = softwareSystem "KMS Key: job-runner (AWS)" "Shared AWS KMS key for job payload encryption/decryption. CFn: kbc-job-runner-kms-key." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-job-runner-azure = softwareSystem "Key Vault Key: job-runner (Azure)" "Shared Azure Key Vault key for job payload encryption/decryption." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-job-runner-gcp = softwareSystem "Cloud KMS Key: job-runner (GCP)" "Shared GCP Cloud KMS key for job payload encryption/decryption." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    # --- Service-owned KMS / Key Vault keys ---
+
+    kms-key-ai-aws = softwareSystem "KMS Key: ai-service (AWS)" "AI service dedicated AWS KMS key." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-ai-azure = softwareSystem "Key Vault: ai-service (Azure)" "AI service dedicated Azure Key Vault." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-ai-gcp = softwareSystem "Cloud KMS Key: ai-service (GCP)" "AI service dedicated GCP Cloud KMS key." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    kms-key-scheduler-aws = softwareSystem "KMS Key: scheduler (AWS)" "Scheduler dedicated AWS KMS key." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-scheduler-azure = softwareSystem "Key Vault: scheduler (Azure)" "Scheduler dedicated Azure Key Vault key." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-scheduler-gcp = softwareSystem "Cloud KMS Key: scheduler (GCP)" "Scheduler dedicated GCP Cloud KMS key." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    kms-key-editor-aws = softwareSystem "KMS Key: editor-service (AWS)" "Editor service dedicated AWS KMS key." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-editor-azure = softwareSystem "Key Vault: editor-service (Azure)" "Editor service dedicated Azure Key Vault key." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-editor-gcp = softwareSystem "Cloud KMS Key: editor-service (GCP)" "Editor service dedicated GCP Cloud KMS key." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    kms-key-oauth-aws = softwareSystem "KMS Key: oauth-service (AWS)" "OAuth service dedicated AWS KMS key for ObjectEncryptor." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-oauth-azure = softwareSystem "Key Vault: oauth-service (Azure)" "OAuth service dedicated Azure Key Vault key." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-oauth-gcp = softwareSystem "Cloud KMS Key: oauth-service (GCP)" "OAuth service dedicated GCP Cloud KMS key." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    kms-key-stream-aws = softwareSystem "KMS Key: stream (AWS)" "Stream service dedicated AWS KMS key. Encrypts data payloads written to disk volumes." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-stream-azure = softwareSystem "Key Vault: stream (Azure)" "Stream service dedicated Azure Key Vault key. Encrypts data payloads written to disk volumes." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-stream-gcp = softwareSystem "Cloud KMS Key: stream (GCP)" "Stream service dedicated GCP Cloud KMS key. Encrypts data payloads written to disk volumes." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    kms-key-ai-chat-gcp = softwareSystem "Cloud KMS Key: ai-chat GCS bucket (GCP)" "GCP-only. Used for GCS bucket encryption-at-rest for KAI app storage buckets. Not application-level encryption." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    # --- sandboxes-service KMS keys (service-owned) ---
+
+    kms-key-sandboxes-service-aws = softwareSystem "KMS Key: sandboxes-service (AWS)" "Service-owned AWS KMS key for sandboxes-service internal encryption. Resource: aws_kms_key.sandboxes_service." {
+        tags "CloudResource" "KMS" "AWS"
+    }
+    kms-key-sandboxes-service-azure = softwareSystem "Key Vault Key: sandboxes-service (Azure)" "Service-owned Azure Key Vault key for sandboxes-service internal encryption." {
+        tags "CloudResource" "KeyVault" "Azure"
+    }
+    kms-key-sandboxes-service-gcp = softwareSystem "GCP KMS Key: sandboxes-service (GCP)" "Service-owned GCP Cloud KMS key for sandboxes-service internal encryption." {
+        tags "CloudResource" "KMS" "GCP"
+    }
+
+    # --- sandboxes-service Pattern B queues (subscriber-owned, fan-out from Connection) ---
+
+    sqs-queue-sandboxes-service-connection-events = softwareSystem "SQS Queue: sandboxes-service-connection-events (AWS)" "Subscriber-owned SQS queue. Receives Connection events via SNS fan-out." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-sandboxes-service-connection-events = softwareSystem "Service Bus Queue: sandboxes-service-connection-events (Azure)" "Subscriber-owned Service Bus queue. Receives Connection events via Event Grid." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-sandboxes-service-connection-events = softwareSystem "Pub/Sub Sub: sandboxes-service-connection-events (GCP)" "Subscriber-owned Pub/Sub subscription. Receives Connection events." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    sqs-queue-sandboxes-service-connection-audit-log = softwareSystem "SQS Queue: sandboxes-service-connection-audit-log (AWS)" "Subscriber-owned SQS queue. Receives Connection audit log events via SNS fan-out." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-sandboxes-service-connection-audit-log = softwareSystem "Service Bus Queue: sandboxes-service-connection-audit-log (Azure)" "Subscriber-owned Service Bus queue. Receives Connection audit log events via Event Grid." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-sandboxes-service-connection-audit-log = softwareSystem "Pub/Sub Sub: sandboxes-service-connection-audit-log (GCP)" "Subscriber-owned Pub/Sub subscription. Receives Connection audit log events." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    # --- KAI Assistant apps (ai-chat, kai-assistant, kai-agent) ---
+    # All three apps use the same Terraform module (app-ai-chat) with different namespace values.
+
+    postgresql-instance = softwareSystem "PostgreSQL" "Shared PostgreSQL instance. Hosts databases for: kai-assistant (ai_chat, kai_assistant, kai_agent), query-service (query_service), metastore (metastore_service). Provisioned by rds_postgresql.tf. Hosted on the cloud-specific managed service per stack (AWS RDS / Azure Database for PostgreSQL / Cloud SQL); see Architecture-wide conventions for why no provider tag." {
+        tags "CloudResource" "PostgreSQL"
+    }
+
+    s3-bucket-ai-chat-storage = softwareSystem "S3 Bucket: kai-app-storage (AWS)" "Per-app S3 buckets for KAI app file storage. One bucket per app namespace (ai-chat, kai-assistant, kai-agent)." {
+        tags "CloudResource" "S3" "AWS"
+    }
+    abs-ai-chat-storage = softwareSystem "Azure Blob Storage: kai-app-storage (Azure)" "Per-app Azure Blob Storage accounts for KAI app file storage." {
+        tags "CloudResource" "ABS" "Azure"
+    }
+    gcs-ai-chat-storage = softwareSystem "GCS Bucket: kai-app-storage (GCP)" "Per-app GCS buckets for KAI app file storage." {
+        tags "CloudResource" "GCS" "GCP"
+    }
+
+    # --- Connection internal queues ---
+    # main and commands: Pattern A (Connection publishes directly to SQS/Service Bus/Pub/Sub).
+    # events-elastic, audit-log-events, table-triggers, search-index: Pattern B subscriber queues
+    #   fanned out from the corresponding fan-out topic (see Cross-service fan-out topics below).
+
+    sqs-queue-connection-main = softwareSystem "SQS Queue: connection-main (AWS)" "Connection internal main queue. Pattern A: connection publishes; connection-worker-main consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-main = softwareSystem "Service Bus Queue: connection-main (Azure)" "Connection internal main queue. Pattern A: connection publishes; connection-worker-main consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-connection-main = softwareSystem "Pub/Sub Topic: connection-main (GCP)" "Connection internal main queue. Pattern A: connection publishes; connection-worker-main consumes." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    sqs-queue-connection-commands = softwareSystem "SQS Queue: connection-commands (AWS)" "Connection internal commands queue. Pattern A: connection publishes; connection-worker-commands consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-commands = softwareSystem "Service Bus Queue: connection-commands (Azure)" "Connection internal commands queue. Pattern A: connection publishes; connection-worker-commands consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-connection-commands = softwareSystem "Pub/Sub Topic: connection-commands (GCP)" "Connection internal commands queue. Pattern A: connection publishes; connection-worker-commands consumes." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    sqs-queue-connection-events-elastic = softwareSystem "SQS Queue: connection-events-elastic (AWS)" "Connection-owned subscriber queue subscribed to sns-topic-connection-events. connection-worker-events-elastic consumes and feeds events into Elasticsearch." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-events-elastic = softwareSystem "Service Bus Queue: connection-events-elastic (Azure)" "Connection-owned subscriber queue subscribed to eventgrid-topic-connection-events. connection-worker-events-elastic consumes and feeds events into Elasticsearch." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-connection-events-elastic = softwareSystem "Pub/Sub Sub: connection-events-elastic (GCP)" "Connection-owned subscription on pubsub-topic-connection-events. connection-worker-events-elastic consumes and feeds events into Elasticsearch." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    sqs-queue-connection-audit-log-events = softwareSystem "SQS Queue: connection-audit-log-events (AWS)" "Connection-owned subscriber queue subscribed to sns-topic-connection-audit-log. connection-worker-audit-log consumes. AWS resource: QueueAuditLogEvents." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-audit-log-events = softwareSystem "Service Bus Queue: connection-audit-log-events (Azure)" "Connection-owned subscriber queue subscribed to eventgrid-topic-connection-audit-log. connection-worker-audit-log consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-connection-audit-log-events = softwareSystem "Pub/Sub Sub: connection-audit-log-events (GCP)" "Connection-owned subscription on pubsub-topic-connection-audit-log. connection-worker-audit-log consumes." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    sqs-queue-connection-table-triggers = softwareSystem "SQS Queue: connection-table-triggers (AWS)" "Connection-owned subscriber queue subscribed to sns-topic-connection-events with filter eventName=storage.tableImportDone. connection-worker-triggers consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-table-triggers = softwareSystem "Service Bus Queue: connection-table-triggers (Azure)" "Connection-owned subscriber queue subscribed to eventgrid-topic-connection-events with included_event_types=storage.tableImportDone. connection-worker-triggers consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-connection-table-triggers = softwareSystem "Pub/Sub Sub: connection-table-triggers (GCP)" "Connection-owned subscription on pubsub-topic-connection-events filtered to storage.tableImportDone. connection-worker-triggers consumes." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    sqs-queue-connection-search-index = softwareSystem "SQS Queue: connection-search-index (AWS)" "Connection-owned subscriber queue subscribed to sns-topic-connection-search-index. connection-worker-search-index consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-connection-search-index = softwareSystem "Service Bus Queue: connection-search-index (Azure)" "Connection-owned subscriber queue subscribed to eventgrid-topic-connection-search-index. connection-worker-search-index consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-connection-search-index = softwareSystem "Pub/Sub Sub: connection-search-index (GCP)" "Connection-owned subscription on pubsub-topic-connection-search-index. connection-worker-search-index consumes." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    # --- Fan-out topics (Connection publishes; subscribers consume via owned queues) ---
+    # Subscribers include both Connection's own internal worker queues and cross-service queues
+    # owned by editor, vault, oauth, sandboxes-service.
+
+    sns-topic-connection-events = softwareSystem "SNS Topic: connection-events (AWS)" "Fan-out topic. Connection publishes project/workspace lifecycle events. Subscribers: connection (events-elastic, table-triggers), editor, vault, oauth, sandboxes-service." {
+        tags "CloudResource" "SNS" "AWS"
+    }
+    eventgrid-topic-connection-events = softwareSystem "Event Grid Topic: connection-events (Azure)" "Fan-out topic for connection events. Subscribers: connection (events-elastic, table-triggers), editor, vault, oauth, sandboxes-service." {
+        tags "CloudResource" "EventGrid" "Azure"
+    }
+    pubsub-topic-connection-events = softwareSystem "Pub/Sub Topic: connection-events (GCP)" "Fan-out topic for connection events. Subscribers: connection (events-elastic, table-triggers), editor, vault, oauth, sandboxes-service." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    sns-topic-connection-audit-log = softwareSystem "SNS Topic: connection-audit-log (AWS)" "Fan-out topic. Connection publishes audit log events. Subscribers: connection (audit-log-events), editor, sandboxes-service." {
+        tags "CloudResource" "SNS" "AWS"
+    }
+    eventgrid-topic-connection-audit-log = softwareSystem "Event Grid Topic: connection-audit-log (Azure)" "Fan-out topic for connection audit log events. Subscribers: connection (audit-log-events), editor, sandboxes-service." {
+        tags "CloudResource" "EventGrid" "Azure"
+    }
+    pubsub-topic-connection-audit-log = softwareSystem "Pub/Sub Topic: connection-audit-log (GCP)" "Fan-out topic for connection audit log events. Subscribers: connection (audit-log-events), editor, sandboxes-service." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    sns-topic-connection-search-index = softwareSystem "SNS Topic: connection-search-index (AWS)" "Fan-out topic for global search index updates. Subscriber: connection (search-index queue) only -- topic ARN is not exposed as a module output." {
+        tags "CloudResource" "SNS" "AWS"
+    }
+    eventgrid-topic-connection-search-index = softwareSystem "Event Grid Topic: connection-search-index (Azure)" "Fan-out topic for global search index updates. Subscriber: connection (search-index queue) only." {
+        tags "CloudResource" "EventGrid" "Azure"
+    }
+    pubsub-topic-connection-search-index = softwareSystem "Pub/Sub Topic: connection-search-index (GCP)" "Fan-out topic for global search index updates. Subscriber: connection (search-index queue) only." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    # --- editor-service internal session queue (Pattern A) ---
+    # Per-cloud names differ. Resources defined in modules/app-editor-service/{aws,azure,gcp}/queue.tf.
+
+    sqs-queue-editor-service-sessions = softwareSystem "SQS Queue: editor-service-sessions (AWS)" "Editor-owned internal queue. Pattern A: editor-api publishes ProcessSessionMessage; editor-session-worker consumes. TF resource: aws_sqs_queue.editor_service_sessions, name 'kbc-editor-service-sessions' (modules/app-editor-service/aws/queue.tf)." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-editor-service-sessions = softwareSystem "Service Bus Queue: session-transition (Azure)" "Editor-owned internal queue. Pattern A: editor-api publishes ProcessSessionMessage; editor-session-worker consumes. TF resource: azurerm_servicebus_queue.editor_service_sessions, queue name 'session-transition' inside dedicated Service Bus namespace 'editor-service-<md5(rg)>' (modules/app-editor-service/azure/queue.tf)." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-editor-service-sessions = softwareSystem "Pub/Sub Topic: editor-service-session-workers (GCP)" "Editor-owned internal topic. Pattern A: editor-api publishes ProcessSessionMessage; editor-session-worker consumes a same-named subscription. TF resource: google_pubsub_topic.editor_service_sessions, topic name 'editor-service-<keboola_stack>-session-workers' with same-named subscription (modules/app-editor-service/gcp/queue.tf)." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    # --- Subscriber-owned queues: editor-service (Pattern B) ---
+    # Per-cloud names differ. Resources defined in modules/app-editor-service/{aws,azure,gcp}/queue_connection.tf.
+
+    sqs-queue-editor-service-connection-events = softwareSystem "SQS Queue: editor-service-connection-events (AWS)" "Editor-owned subscriber queue for Connection events. TF resource: aws_sqs_queue.connection_events, name 'kbc-editor-service-connection-events' (modules/app-editor-service/aws/queue_connection.tf)." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-editor-service-connection-events = softwareSystem "Service Bus Queue: connection-events (Azure)" "Editor-owned subscriber queue for Connection events. TF resource: azurerm_servicebus_queue.connection_events, queue name 'connection-events' inside dedicated Service Bus namespace 'editor-service-<md5(rg)>' (modules/app-editor-service/azure/queue_connection.tf)." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-editor-service-connection-events = softwareSystem "Pub/Sub Sub: editor-service-events-subscription (GCP)" "Editor-owned subscriber subscription for Connection events. TF resource: google_pubsub_subscription.connection_events, name 'editor-servicee-<keboola_stack>-events-subscription' (typo: literal extra 'e' from '${local.app_name}e-' in queue_connection.tf line 21). Subscribes to Connection's pubsub-topic-connection-events." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    sqs-queue-editor-service-connection-audit-log = softwareSystem "SQS Queue: editor-service-connection-audit-log (AWS)" "Editor-owned subscriber queue for Connection audit log events. TF resource: aws_sqs_queue.connection_audit_log_events, name 'kbc-editor-service-connection-audit-log' (modules/app-editor-service/aws/queue_connection.tf)." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-editor-service-connection-audit-log = softwareSystem "Service Bus Queue: connection-audit-log (Azure)" "Editor-owned subscriber queue for Connection audit log events. TF resource: azurerm_servicebus_queue.connection_audit_log, queue name 'connection-audit-log' inside dedicated Service Bus namespace 'editor-service-<md5(rg)>' (modules/app-editor-service/azure/queue_connection.tf)." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-editor-service-connection-audit-log = softwareSystem "Pub/Sub Sub: editor-service-audit-log-subscription (GCP)" "Editor-owned subscriber subscription for Connection audit log events. TF resource: google_pubsub_subscription.connection_audit_log_events, name 'editor-service-<keboola_stack>-audit-log-subscription'. Subscribes to Connection's pubsub-topic-connection-audit-log." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    # --- Subscriber-owned queues: vault (Pattern B) ---
+
+    sqs-queue-vault-connection-events = softwareSystem "SQS Queue: vault-connection-events (AWS)" "Vault-owned subscriber queue for Connection events." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-vault-connection-events = softwareSystem "Service Bus Queue: vault-connection-events (Azure)" "Vault-owned subscriber queue for Connection events." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-vault-connection-events = softwareSystem "Pub/Sub Sub: vault-connection-events (GCP)" "Vault-owned subscriber subscription for Connection events." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    # --- Subscriber-owned queues: oauth-service (Pattern B) ---
+
+    sqs-queue-oauth-connection-events = softwareSystem "SQS Queue: oauth-connection-events (AWS)" "OAuth-owned subscriber queue for Connection events." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-oauth-connection-events = softwareSystem "Service Bus Queue: oauth-connection-events (Azure)" "OAuth-owned subscriber queue for Connection events." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-sub-oauth-connection-events = softwareSystem "Pub/Sub Sub: oauth-connection-events (GCP)" "OAuth-owned subscriber subscription for Connection events." {
+        tags "CloudResource" "PubSub" "GCP" "Queue"
+    }
+
+    # --- Daemon job queues (Pattern A) ---
+
+    sqs-queue-daemon-jobs-to-start = softwareSystem "SQS Queue: daemon-jobs-to-start (AWS)" "Daemon-owned queue for job startup messages. daemon-run publishes; daemon-start consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-daemon-jobs-to-start = softwareSystem "Service Bus Queue: daemon-jobs-to-start (Azure)" "Daemon-owned queue for job startup messages. daemon-run publishes; daemon-start consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-daemon-jobs-to-start = softwareSystem "Pub/Sub Topic: daemon-jobs-to-start (GCP)" "Daemon-owned queue for job startup messages. daemon-run publishes; daemon-start consumes." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    sqs-queue-daemon-flow-jobs-transition = softwareSystem "SQS Queue: daemon-flow-jobs-transition (AWS)" "Daemon-owned queue for flow job state transitions. daemon-run publishes; daemon-flow-transition consumes." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-daemon-flow-jobs-transition = softwareSystem "Service Bus Queue: daemon-flow-jobs-transition (Azure)" "Daemon-owned queue for flow job state transitions. daemon-run publishes; daemon-flow-transition consumes." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-daemon-flow-jobs-transition = softwareSystem "Pub/Sub Topic: daemon-flow-jobs-transition (GCP)" "Daemon-owned queue for flow job state transitions. daemon-run publishes; daemon-flow-transition consumes." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    # --- Notification queues (Pattern A) ---
+
+    sqs-queue-notification-messages = softwareSystem "SQS Queue: notification-messages (AWS)" "Notification-owned internal queue. API publishes events; consumer delivers notifications." {
+        tags "CloudResource" "SQS" "AWS"
+    }
+    servicebus-queue-notification-messages = softwareSystem "Service Bus Queue: notification-messages (Azure)" "Notification-owned internal queue. API publishes events; consumer delivers notifications." {
+        tags "CloudResource" "ServiceBus" "Azure"
+    }
+    pubsub-topic-notification-messages = softwareSystem "Pub/Sub Topic: notification-messages (GCP)" "Notification-owned internal queue. API publishes events; consumer delivers notifications." {
+        tags "CloudResource" "PubSub" "GCP"
+    }
+
+    # --- AI service resources ---
+
+    azure-openai-ai-service = softwareSystem "Azure OpenAI: ai-service" "Azure OpenAI deployment used by ai-service for LLM inference and embeddings." {
+        tags "CloudResource" "OpenAI" "AI" "Azure"
+    }
+
+    storage-ai-vectorstore-aws = softwareSystem "S3 Bucket: ai-vectorstore (AWS)" "AI service S3 bucket for vector store index data." {
+        tags "CloudResource" "S3" "AWS"
+    }
+    storage-ai-vectorstore-azure = softwareSystem "Azure Blob: ai-vectorstore (Azure)" "AI service Azure Blob Storage for vector store index data." {
+        tags "CloudResource" "ABS" "Azure"
+    }
+    storage-ai-vectorstore-gcp = softwareSystem "GCS Bucket: ai-vectorstore (GCP)" "AI service GCS bucket for vector store index data." {
+        tags "CloudResource" "GCS" "GCP"
+    }
+
+    # --- Omnisearch resources ---
+
+    storage-omnisearch-metastore-aws = softwareSystem "S3 Bucket: omnisearch-metastore (AWS)" "Omnisearch S3 bucket for metastore index data." {
+        tags "CloudResource" "S3" "AWS"
+    }
+    storage-omnisearch-metastore-azure = softwareSystem "Azure Blob: omnisearch-metastore (Azure)" "Omnisearch Azure Blob Storage for metastore index data." {
+        tags "CloudResource" "ABS" "Azure"
+    }
+    storage-omnisearch-metastore-gcp = softwareSystem "GCS Bucket: omnisearch-metastore (GCP)" "Omnisearch GCS bucket for metastore index data." {
+        tags "CloudResource" "GCS" "GCP"
+    }
+
+    # --- Shared S3 logs bucket ---
+
+    s3-bucket-logs = softwareSystem "S3 Bucket: logs (AWS)" "Shared S3 logs bucket. CFn: kbc-logs-bucket." {
+        tags "CloudResource" "S3" "AWS"
+    }
+
+    # --- Stream etcd snapshots ---
+
+    efs-stream-etcd-snapshots = softwareSystem "EFS: stream-etcd-snapshots (AWS)" "AWS EFS file system for stream etcd disaster recovery snapshots. NFS mount targets in each subnet, mounted into EKS pods." {
+        tags "CloudResource" "EFS" "AWS"
+    }
+    abs-stream-etcd-snapshots = softwareSystem "ABS: stream-etcd-snapshots (Azure)" "Azure Blob Storage account for stream etcd disaster recovery snapshots." {
+        tags "CloudResource" "ABS" "Azure"
+    }
+    gcs-stream-etcd-snapshots = softwareSystem "GCS Bucket: stream-etcd-snapshots (GCP)" "GCP GCS bucket for stream etcd disaster recovery snapshots." {
+        tags "CloudResource" "GCS" "GCP"
+    }
+
+    # --- Cloud LLM providers (KAI Assistant) ---
+
+    google-vertex-ai = softwareSystem "Google Vertex AI" "Google Vertex AI managed LLM platform. Used by KAI apps on AWS and GCP stacks via Vertex Anthropic API." {
+        tags "CloudResource" "AI" "GCP"
+    }
+    azure-ai-foundry = softwareSystem "Azure AI Foundry" "Azure AI Foundry managed LLM platform. Used by KAI apps on Azure stacks." {
+        tags "CloudResource" "AI" "Azure"
+    }
+
+    # --- E2B (Vendor) ---
+
+    e2b = softwareSystem "E2B" "Sandboxed code execution platform. Used by kai-agent to run Python/JS code in isolated sandboxes." {
+        tags "Vendor"
+    }

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/connection-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/connection-external.dsl
@@ -1,0 +1,126 @@
+# Cloud resource relationships for connection
+# Included at top level of model block in model.dsl
+
+# MySQL -- connection has its own dedicated instance
+connection-storage-api                              -> mysql-instance-connection    "persists all platform data (projects, tokens, configs, events, audit log)"
+connection-manage-api                               -> mysql-instance-connection    "persists organisation and project management data"
+connection-payg-api                                 -> mysql-instance-connection    "persists PAYG billing and credits data"
+connection-worker-main                              -> mysql-instance-connection    "processes storage jobs from main queue"
+connection-worker-commands                          -> mysql-instance-connection    "processes command messages"
+connection-worker-audit-log                         -> mysql-instance-connection    "writes audit log entries"
+connection-worker-events-elastic                    -> mysql-instance-connection    "reads events for Elasticsearch indexing"
+connection-worker-search-index                      -> mysql-instance-connection    "reads data for global search index"
+connection-worker-triggers                          -> mysql-instance-connection    "reads table trigger configurations"
+connection-worker-user-tasks-scheduler              -> mysql-instance-connection    "reads scheduled tasks and enqueues storage jobs"
+connection-worker-monitoring                        -> mysql-instance-connection    "reads storage backend credentials for health checks"
+connection-worker-certificate-rotation              -> mysql-instance-connection    "reads and writes storage backend certificate records"
+connection-cronjob-token-expiration                 -> mysql-instance-connection    "deletes expired storage/manage tokens, invitations, sessions, and project-admin associations"
+connection-cronjob-project-purge-scheduler          -> mysql-instance-connection    "reads deleted projects due for purge"
+connection-cronjob-sync-apps                        -> mysql-instance-connection    "writes synced UI app definitions from reference Connection stack"
+connection-cronjob-sync-components                  -> mysql-instance-connection    "writes synced component definitions to the apis table"
+connection-cronjob-storage-jobs-table-partitioning  -> mysql-instance-connection    "manages bi_storage_jobs MySQL range partitions"
+connection-cronjob-global-search-table-partitioning -> mysql-instance-connection    "manages bi_gs_consistency MySQL range partitions"
+connection-cronjob-add-audit-log-partition          -> mysql-instance-connection    "manages bi_auditLog MySQL range partitions"
+connection-cronjob-snapshot-project-metrics         -> mysql-instance-connection    "snapshots per-project metrics"
+connection-cronjob-workers-expiration               -> mysql-instance-connection    "expires stale workers"
+connection-cronjob-clear-expired-oauth-tokens       -> mysql-instance-connection    "clears expired OAuth 2 server tokens"
+
+# Connection internal queues (Pattern A -- Connection both publishes and workers consume)
+# main
+connection-storage-api                              -> sqs-queue-connection-main              "enqueues storage jobs on AWS stacks"
+connection-worker-main                              -> sqs-queue-connection-main              "consumes storage jobs on AWS stacks"
+connection-worker-user-tasks-scheduler              -> sqs-queue-connection-main              "enqueues scheduled storage jobs on AWS stacks"
+connection-storage-api                              -> servicebus-queue-connection-main       "enqueues storage jobs on Azure stacks"
+connection-worker-main                              -> servicebus-queue-connection-main       "consumes storage jobs on Azure stacks"
+connection-worker-user-tasks-scheduler              -> servicebus-queue-connection-main       "enqueues scheduled storage jobs on Azure stacks"
+connection-storage-api                              -> pubsub-topic-connection-main           "enqueues storage jobs on GCP stacks"
+connection-worker-main                              -> pubsub-topic-connection-main           "consumes storage jobs on GCP stacks"
+connection-worker-user-tasks-scheduler              -> pubsub-topic-connection-main           "enqueues scheduled storage jobs on GCP stacks"
+
+# commands
+connection-storage-api                              -> sqs-queue-connection-commands          "enqueues CLI commands on AWS stacks"
+connection-cronjob-project-purge-scheduler          -> sqs-queue-connection-commands          "enqueues project-purge commands on AWS stacks"
+connection-worker-commands                          -> sqs-queue-connection-commands          "consumes commands on AWS stacks"
+connection-storage-api                              -> servicebus-queue-connection-commands   "enqueues CLI commands on Azure stacks"
+connection-cronjob-project-purge-scheduler          -> servicebus-queue-connection-commands   "enqueues project-purge commands on Azure stacks"
+connection-worker-commands                          -> servicebus-queue-connection-commands   "consumes commands on Azure stacks"
+connection-storage-api                              -> pubsub-topic-connection-commands       "enqueues CLI commands on GCP stacks"
+connection-cronjob-project-purge-scheduler          -> pubsub-topic-connection-commands       "enqueues project-purge commands on GCP stacks"
+connection-worker-commands                          -> pubsub-topic-connection-commands       "consumes commands on GCP stacks"
+
+# eventsElastic (subscriber queue, fanned out from sns-topic-connection-events)
+connection-worker-events-elastic                    -> sqs-queue-connection-events-elastic           "consumes events for Elasticsearch indexing on AWS stacks"
+connection-worker-events-elastic                    -> servicebus-queue-connection-events-elastic    "consumes events for Elasticsearch indexing on Azure stacks"
+connection-worker-events-elastic                    -> pubsub-sub-connection-events-elastic          "consumes events for Elasticsearch indexing on GCP stacks"
+
+# auditLogEvents (subscriber queue, fanned out from sns-topic-connection-audit-log)
+connection-worker-audit-log                         -> sqs-queue-connection-audit-log-events          "consumes audit log entries on AWS stacks"
+connection-worker-audit-log                         -> servicebus-queue-connection-audit-log-events   "consumes audit log entries on Azure stacks"
+connection-worker-audit-log                         -> pubsub-sub-connection-audit-log-events         "consumes audit log entries on GCP stacks"
+
+# tableTriggers (subscriber queue, fanned out from sns-topic-connection-events with filter storage.tableImportDone)
+connection-worker-triggers                          -> sqs-queue-connection-table-triggers          "consumes table trigger events on AWS stacks"
+connection-worker-triggers                          -> servicebus-queue-connection-table-triggers   "consumes table trigger events on Azure stacks"
+connection-worker-triggers                          -> pubsub-sub-connection-table-triggers         "consumes table trigger events on GCP stacks"
+
+# searchIndex (Symfony Messenger transport; subscriber queue fanned out from sns-topic-connection-search-index)
+connection-worker-search-index                      -> sqs-queue-connection-search-index          "consumes search index updates on AWS stacks"
+connection-worker-search-index                      -> servicebus-queue-connection-search-index   "consumes search index updates on Azure stacks"
+connection-worker-search-index                      -> pubsub-sub-connection-search-index         "consumes search index updates on GCP stacks"
+
+# Fan-out topics (Connection publishes; subscribers consume via owned queues)
+# events: subscribers are connection's own (events-elastic, table-triggers) plus editor, vault, oauth, sandboxes-service
+connection-storage-api                              -> sns-topic-connection-events           "publishes storage events on AWS stacks"
+connection-storage-api                              -> eventgrid-topic-connection-events     "publishes storage events on Azure stacks"
+connection-storage-api                              -> pubsub-topic-connection-events        "publishes storage events on GCP stacks"
+
+# audit-log: subscribers are connection's own (audit-log-events) plus editor, sandboxes-service
+connection-storage-api                              -> sns-topic-connection-audit-log        "publishes audit log entries on AWS stacks"
+connection-storage-api                              -> eventgrid-topic-connection-audit-log  "publishes audit log entries on Azure stacks"
+connection-storage-api                              -> pubsub-topic-connection-audit-log     "publishes audit log entries on GCP stacks"
+
+# search-index: only connection's own search-index queue subscribes (topic ARN is not exposed)
+connection-storage-api                              -> sns-topic-connection-search-index           "publishes search index updates on AWS stacks"
+connection-storage-api                              -> eventgrid-topic-connection-search-index     "publishes search index updates on Azure stacks"
+connection-storage-api                              -> pubsub-topic-connection-search-index        "publishes search index updates on GCP stacks"
+
+# Topic subscriptions: Connection-owned subscriber queues receive from Connection's fan-out topics
+sqs-queue-connection-events-elastic           -> sns-topic-connection-events            "subscribed via aws_sns_topic_subscription"
+servicebus-queue-connection-events-elastic    -> eventgrid-topic-connection-events      "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-connection-events-elastic          -> pubsub-topic-connection-events         "subscribed via google_pubsub_subscription"
+
+sqs-queue-connection-audit-log-events         -> sns-topic-connection-audit-log         "subscribed via aws_sns_topic_subscription"
+servicebus-queue-connection-audit-log-events  -> eventgrid-topic-connection-audit-log   "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-connection-audit-log-events        -> pubsub-topic-connection-audit-log      "subscribed via google_pubsub_subscription"
+
+sqs-queue-connection-table-triggers           -> sns-topic-connection-events            "subscribed via aws_sns_topic_subscription with filter eventName=storage.tableImportDone"
+servicebus-queue-connection-table-triggers    -> eventgrid-topic-connection-events      "subscribed via azurerm_eventgrid_event_subscription with included_event_types=storage.tableImportDone"
+pubsub-sub-connection-table-triggers          -> pubsub-topic-connection-events         "subscribed via google_pubsub_subscription with filter on storage.tableImportDone"
+
+sqs-queue-connection-search-index             -> sns-topic-connection-search-index      "subscribed via aws_sns_topic_subscription"
+servicebus-queue-connection-search-index      -> eventgrid-topic-connection-search-index "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-connection-search-index            -> pubsub-topic-connection-search-index   "subscribed via google_pubsub_subscription"
+
+# S3 logs bucket
+connection-storage-api                              -> s3-bucket-logs "stores debug log attachments"
+
+# SaaS integrations
+# SendGrid is used by multiple components (all three APIs + certificate-rotation worker)
+connection-storage-api                              -> sendgrid "sends token sharing and merge request lifecycle emails"
+connection-manage-api                               -> sendgrid "sends project invitations and Snowflake Partner Connect welcome emails"
+connection-payg-api                                 -> sendgrid "sends PAYG registration welcome emails"
+connection-worker-certificate-rotation              -> sendgrid "sends SAML2 certificate expiry warnings to backend technical owners"
+connection-payg-api                                 -> stripe   "processes pay-as-you-go credit purchases and webhook events"
+
+# Developer Portal
+connection-cronjob-sync-components                  -> devPortalApi "fetches component definitions for sync into local database"
+
+# Storage backends
+connection-worker-monitoring                        -> snowflake "tests live connections to customer Snowflake accounts (health checks)"
+connection-worker-monitoring                        -> bigquery  "tests live connections to customer BigQuery accounts (health checks)"
+connection-worker-certificate-rotation              -> snowflake "executes DDL on customer Snowflake accounts (ALTER USER SET RSA_PUBLIC_KEY_N)"
+
+# Kubernetes API
+connection-cronjob-release-staled-locks             -> aws-eks   "lists pods to release stale locks on AWS stacks"
+connection-cronjob-release-staled-locks             -> azure-aks "lists pods to release stale locks on Azure stacks"
+connection-cronjob-release-staled-locks             -> gcp-gke   "lists pods to release stale locks on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/connection.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/connection.dsl
@@ -1,0 +1,11 @@
+# L3 inter-service relationships for connection
+# Included inside keboolaPlatform block in model.dsl
+
+connection-storage-api                     -> connection-elasticsearch "Indexes and queries events, files, and global search data"
+connection-manage-api                      -> connection-elasticsearch "Queries global search index for manage-scoped searches"
+connection-worker-events-elastic           -> connection-elasticsearch "Writes event records to search index"
+connection-worker-search-index             -> connection-elasticsearch "Maintains global search index"
+connection-cronjob-delete-events-indices   -> connection-elasticsearch "Deletes old events indices"
+connection-cronjob-roll-elastic-events-index -> connection-elasticsearch "Rolls active events index"
+connection-worker-triggers                 -> queue-public-api "Creates component jobs via Queue API (table trigger fired)"
+connection-manage-api                      -> sandboxes        "Updates sandbox credentials during BYODB migrations and Snowflake hostname changes (CLI commands)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/connection.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/connection.md
@@ -1,0 +1,66 @@
+# connection — dependency analysis
+
+## Deployed components
+
+### API (one Deployment, three logical C4 components)
+- `connection-storage-api`: REST API `/v1`, `/v2` — Storage tokens, project-scoped
+- `connection-manage-api`: REST API `/manage` — Manage tokens, org-scoped
+- `connection-payg-api`: REST API `/pay-as-you-go` — PAYG billing
+
+### Queue workers (Deployments)
+- `connection-worker-main`: consumes `main` queue
+- `connection-worker-commands`: consumes `commands` queue
+- `connection-worker-audit-log`: consumes `auditLog` queue
+- `connection-worker-events-elastic`: consumes `eventsElastic` queue; indexes events into Elasticsearch
+- `connection-publish-worker-metrics`: publishes worker metrics
+- `connection-worker-search-index`: Messenger consumer `searchIndex`; maintains global search index
+- `connection-worker-user-tasks-scheduler`: Symfony Scheduler `user_tasks`; reads due tasks, dispatches `StorageJobMessage` via cloud queue
+- `connection-worker-triggers`: consumes `tableTriggers` queue; fires component jobs via Queue Public API
+- `connection-worker-monitoring`: Symfony Scheduler `monitoring`; tests live connections to all customer Snowflake/BigQuery backends
+- `connection-worker-certificate-rotation`: Symfony Scheduler `certificate-rotation`; reads/writes MySQL backend credentials; executes DDL directly on customer Snowflake accounts
+
+### CronJobs
+- `connection-cronjob-token-expiration`: expires tokens, sessions, invitations; dispatches expiry events (every minute)
+- `connection-cronjob-project-purge-scheduler`: enqueues project purge jobs (every 15 min)
+- `connection-cronjob-add-audit-log-partition`: MySQL DDL on `bi_auditLog` (yearly)
+- `connection-cronjob-delete-events-indices`: deletes old Elasticsearch events indices (monthly)
+- `connection-cronjob-roll-elastic-events-index`: rolls active Elasticsearch events index (monthly)
+- `connection-cronjob-snapshot-project-metrics`: snapshots per-project metrics (hourly)
+- `connection-cronjob-storage-jobs-table-partitioning`: MySQL DDL on `bi_storage_jobs` (daily)
+- `connection-cronjob-global-search-table-partitioning`: MySQL DDL on `bi_gs_consistency` (daily)
+- `connection-cronjob-sync-apps`: downloads UI app definitions from reference Connection stack (every 5 min)
+- `connection-cronjob-workers-expiration`: expires stale workers (daily)
+- `connection-cronjob-release-staled-locks`: releases locks held by terminated pods (every 2 min)
+- `connection-cronjob-clear-expired-oauth-tokens`: deletes expired OAuth2 server tokens (hourly)
+- `connection-cronjob-sync-components`: fetches component definitions from Developer Portal (conditional)
+
+## Inter-service dependencies (within keboolaPlatform)
+- `connection-worker-triggers` -> `queue-public-api`: `Keboola\JobQueueClient\Client` via `stackInfo->getService('queue')` — fires component jobs when table triggers activate
+- `connection-manage-api` -> `sandboxes`: `Keboola\Sandboxes\Api\ManageClient` via `stackInfo->getService('sandboxes')` — CLI commands only (Snowflake hostname change, BYODB migration)
+- `connection-storage-api`, `connection-manage-api`, `connection-worker-events-elastic`, `connection-worker-search-index`, `connection-cronjob-delete-events-indices`, `connection-cronjob-roll-elastic-events-index` -> `elasticsearch`
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-connection` | MySQL instance | connection only | `mysql_config = local.connection_mysql_config` in app_connection.tf; CFn: kbc-connection-rds |
+| `sns-topic-connection-events` | SNS topic | editor (subscriber), vault (subscriber) | `connection_events_topic_arn` output from `module.connection_app` in app_connection.tf |
+| `sns-topic-connection-audit-log` | SNS topic | editor (subscriber) | `connection_audit_log_topic_arn` output from `module.connection_app` in app_connection.tf |
+| `s3-bucket-logs` | Object storage | sync-actions, omnisearch | `s3_logs_bucket = data.aws_cloudformation_stack.kbc_logs_bucket...` in app_connection.tf |
+| `sendgrid` | SaaS | — | SMTP relay via `smtp.sendgrid.net`; project invitations, token sharing, notifications |
+| `stripe` | SaaS | — | `PayAsYouGo_Service_Stripe` in connection-payg-api; credit purchases and webhook events |
+
+## External storage backends (via connection-storage-api)
+| System | Status | Evidence |
+|---|---|---|
+| `snowflake` | Active | `Package/StorageDriverSnowflake` |
+| `bigquery` | Active | `Package/StorageDriverBigQuery` |
+| `synapse` | Legacy | `SynapseConnectionManager` in legacy-app |
+| `exasol` | Legacy | `StorageDriverExasol` in legacy-app |
+| `supabase` | Uncommissioned | `Package/StorageDriverSupabase` |
+
+## Notes
+- Elasticsearch config is injected by the Helm chart's cert-copy job via `connection-elasticsearch-urls` secret — not in Terraform infra_secrets.
+- Connection uses its own symmetric `ENCRYPTION_KEYS__*` env vars for token encryption — NOT `Keboola\ObjectEncryptor` / KMS. No KMS/Key Vault dependency.
+- `%keboolaServices%` exposes service URLs to callers. Only `queue` and `sandboxes` are consumed internally. `oauth`, `import`, `syrup` are pass-through only — not modelled as inter-service dependencies.
+- Storage jobs (`Storage_Service_Jobs`, `bi_storage_jobs`) are internal Connection operations — unrelated to the Queue service. Do not confuse with component jobs (`Keboola\JobQueueClient`).
+- `connection-cronjob-sync-apps` calls another Connection instance via HTTP — a cross-stack self-call, not an inter-service dependency.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service-external.dsl
@@ -1,0 +1,39 @@
+# Cloud resource relationships for editor-service
+# Included at top level of model block in model.dsl
+
+editor-api            -> mysql-instance-job-queue "persists application data (shares job-queue MySQL instance)"
+editor-api            -> kms-key-editor-aws   "encrypts data at rest on AWS stacks"
+editor-api            -> kms-key-editor-azure "encrypts data at rest on Azure stacks"
+editor-api            -> kms-key-editor-gcp   "encrypts data at rest on GCP stacks"
+
+editor-session-worker -> mysql-instance-job-queue "persists session state (shares job-queue MySQL instance)"
+editor-session-worker -> kms-key-editor-aws   "encrypts session tokens on AWS stacks"
+editor-session-worker -> kms-key-editor-azure "encrypts session tokens on Azure stacks"
+editor-session-worker -> kms-key-editor-gcp   "encrypts session tokens on GCP stacks"
+
+# Internal session queue -- Pattern A (editor-api publishes, editor-session-worker consumes)
+editor-api            -> sqs-queue-editor-service-sessions        "publishes ProcessSessionMessage on AWS stacks"
+editor-api            -> servicebus-queue-editor-service-sessions "publishes ProcessSessionMessage on Azure stacks"
+editor-api            -> pubsub-topic-editor-service-sessions     "publishes ProcessSessionMessage on GCP stacks"
+
+editor-session-worker -> sqs-queue-editor-service-sessions        "consumes ProcessSessionMessage on AWS stacks"
+editor-session-worker -> servicebus-queue-editor-service-sessions "consumes ProcessSessionMessage on Azure stacks"
+editor-session-worker -> pubsub-topic-editor-service-sessions     "consumes ProcessSessionMessage on GCP stacks"
+
+# Connection events consumer -- Pattern B fan-out subscriptions
+editor-consumer       -> sqs-queue-editor-service-connection-events        "consumes connection events on AWS stacks"
+editor-consumer       -> servicebus-queue-editor-service-connection-events "consumes connection events on Azure stacks"
+editor-consumer       -> pubsub-sub-editor-service-connection-events       "consumes connection events on GCP stacks"
+
+editor-consumer       -> sqs-queue-editor-service-connection-audit-log        "consumes audit log events on AWS stacks"
+editor-consumer       -> servicebus-queue-editor-service-connection-audit-log "consumes audit log events on Azure stacks"
+editor-consumer       -> pubsub-sub-editor-service-connection-audit-log       "consumes audit log events on GCP stacks"
+
+# Service-owned queues receive from Connection's topics (fan-out topology)
+sqs-queue-editor-service-connection-events        -> sns-topic-connection-events       "subscribed via aws_sns_topic_subscription"
+servicebus-queue-editor-service-connection-events -> eventgrid-topic-connection-events "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-editor-service-connection-events       -> pubsub-topic-connection-events    "subscribed via google_pubsub_subscription"
+
+sqs-queue-editor-service-connection-audit-log        -> sns-topic-connection-audit-log       "subscribed via aws_sns_topic_subscription"
+servicebus-queue-editor-service-connection-audit-log -> eventgrid-topic-connection-audit-log "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-editor-service-connection-audit-log       -> pubsub-topic-connection-audit-log    "subscribed via google_pubsub_subscription"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service.dsl
@@ -1,0 +1,8 @@
+# L3 inter-service relationships for editor-service
+# Included inside keboolaPlatform block in model.dsl
+
+editor-api -> connection      "reads storage, verifies tokens, manages configs"
+editor-api -> sandboxes       "provisions and manages workspaces"
+editor-api -> query           "runs SQL queries and table previews"
+editor-consumer -> connection "Receives connection events and audit log (async, via queue)"
+editor-session-worker -> connection "polls workspace jobs and manages workspace lifecycle via Storage API"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/editor-service.md
@@ -1,0 +1,25 @@
+# editor-service — dependency analysis
+
+## Deployed components
+- `editor-api` (Deployment): container `app` (PHP API)
+- `editor-consumer` (Deployment, two instances — one per consumerTransport: `connection-audit-log`, `connection-events`): command `messenger:consume <transportName>`
+- `editor-session-worker` (Deployment): command `messenger:consume sessionsToProcess`
+
+## Inter-service dependencies
+- `editor-api` -> `connection`: `getConnectionServiceUrl` via `Keboola\StorageApiBranch\Factory\ClientOptions` and `Keboola\ManageApi\Client` in services.yaml
+- `editor-api` -> `sandboxes`: `getSandboxesApiUrl` via `App\Client\SandboxesClientFactory` in services.yaml
+- `editor-api` -> `query`: `getQueryServiceUrl` via `App\Client\QueryApiClientFactory` and `RunQueryAction`/`TablePreviewAction` controllers
+- `editor-consumer` -> `connection`: inter-service — subscribes to `connection_events` and `connection_audit_log` topics published by Connection
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, scheduler, vault, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_editor.tf |
+| `sqs-queue-editor-service-sessions` | SQS queue (AWS, Pattern A) | -- (service-owned) | `aws_sqs_queue.editor_service_sessions` (`kbc-editor-service-sessions`) in modules/app-editor-service/aws/queue.tf; DSN exposed as `SESSION_QUEUE_DSN` |
+| `servicebus-queue-editor-service-sessions` | Service Bus queue (Azure, Pattern A) | -- (service-owned) | `azurerm_servicebus_queue.editor_service_sessions` (queue `session-transition` in dedicated namespace `editor-service-<md5>`) in modules/app-editor-service/azure/queue.tf |
+| `pubsub-topic-editor-service-sessions` | Pub/Sub topic+subscription (GCP, Pattern A) | -- (service-owned) | `google_pubsub_topic.editor_service_sessions` (`editor-service-<stack>-session-workers`) with same-named subscription in modules/app-editor-service/gcp/queue.tf |
+| `sns-topic-connection-events` | SNS topic | connection (publisher), vault | `connection_events_topic_arn = module.connection_app.connection_events_topic_arn` in app_editor.tf |
+| `sns-topic-connection-audit-log` | SNS topic | connection (publisher) | `connection_audit_log_topic_arn = module.connection_app.connection_audit_log_topic_arn` in app_editor.tf |
+
+## Unresolved
+- `applicationToken` in values.yaml (`APPLICATION_TOKEN`) — Manage API token, not a service URL dependency. Used for `Keboola\ManageApi\Client` already captured via `connection`.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api-external.dsl
@@ -1,0 +1,6 @@
+# Cloud resource relationships for encryption-api
+# Included at top level of model block in model.dsl
+
+encryption-api -> kms-key-job-runner-aws   "encrypts and decrypts configuration values on AWS stacks"
+encryption-api -> kms-key-job-runner-azure "encrypts and decrypts configuration values on Azure stacks"
+encryption-api -> kms-key-job-runner-gcp   "encrypts and decrypts configuration values on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api.dsl
@@ -1,0 +1,4 @@
+# L3 inter-service relationships for encryption-api
+# Included inside keboolaPlatform block in model.dsl
+
+encryption-api -> connection "Validates storage tokens for encrypt/decrypt requests"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/encryption-api.md
@@ -1,0 +1,20 @@
+# encryption-api — dependency analysis
+
+## Deployed components
+- `encryption-api` (Deployment): PHP REST API
+
+## Inter-service dependencies
+- `encryption-api` -> `connection`: `Keboola\StorageApiBranch\Factory\StorageClientPlainFactory` in services.yaml — token validation
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `kms-key-job-runner-aws` | KMS key (AWS) | job-queue-daemon, queue-runner, sync-actions | `job_runner_kms_key_id = data.aws_cloudformation_stack.kbc_job_runner_kms_key...` in app_encryption_api.tf |
+| `kms-key-job-runner-azure` | Key Vault key (Azure) | job-queue-daemon, queue-runner, sync-actions | `AZURE_KEY_VAULT_URL` in azure/main.tf |
+| `kms-key-job-runner-gcp` | Cloud KMS key (GCP) | job-queue-daemon, queue-runner, sync-actions | `GCP_KMS_KEY_ID` in gcp/main.tf |
+
+## Unresolved
+None.
+
+## Notes
+- The migration feature (`ConfigurationMigrator`) instantiates `ObjectEncryptor` for multiple remote stacks using their KMS keys. These are still the same three shared keys (`kms-key-job-runner-aws/azure/gcp`) — just used for cross-stack re-encryption, not additional key dependencies.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/external-systems.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/external-systems.dsl
@@ -1,0 +1,90 @@
+    # -------------------------------------------------------------------------
+    # External Systems — Cloud Vendors (L1 aggregated only)
+    # -------------------------------------------------------------------------
+    # Granular type-level vendor nodes (aws-kms, aws-sqs etc.) have been removed.
+    # Individual named resource instances are defined in cloud-resources.dsl.
+    # -------------------------------------------------------------------------
+
+    aws   = softwareSystem "Amazon Web Services" "Cloud infrastructure provider. EKS, RDS, S3, KMS, SQS, SNS and more." {
+        tags "Vendor" "CloudProvider"
+        url "https://aws.amazon.com"
+    }
+    azure = softwareSystem "Microsoft Azure" "Cloud infrastructure provider. AKS, Azure Database, ABS, Key Vault, Service Bus, Event Grid, Azure OpenAI." {
+        tags "Vendor" "CloudProvider"
+        url "https://azure.microsoft.com"
+    }
+    gcp   = softwareSystem "Google Cloud" "Cloud infrastructure provider. GKE, Cloud SQL, GCS, Cloud KMS, Pub/Sub." {
+        tags "Vendor" "CloudProvider"
+        url "https://cloud.google.com"
+    }
+
+    datadog = softwareSystem "Datadog" "Observability platform. Metrics, traces, logs, and APM across all platform services. Implicit dependency — every service ships telemetry to Datadog." {
+        tags "Vendor"
+        url "https://www.datadoghq.com"
+    }
+
+    langsmith = softwareSystem "LangSmith" "LLM observability and tracing platform. Implicit dependency — KAI apps (ai-chat, kai-assistant, kai-agent) ship LLM call traces to LangSmith. Same modelling treatment as Datadog: platform-level L1 relationship only, never per-component." {
+        tags "Vendor"
+        url "https://smith.langchain.com"
+    }
+
+    github = softwareSystem "GitHub" "Source code hosting and Git service. Accessed at runtime by templates-api to clone template repositories (keboola/keboola-as-code-templates). Operational dependency, not just development." {
+        tags "Vendor"
+        url "https://github.com"
+    }
+
+    # --- Marketplaces ---
+    azure-marketplace  = softwareSystem "Azure Marketplace" "Microsoft Azure Marketplace. Used for PAYG subscription management and metered usage reporting on Azure stacks." {
+        tags "Vendor"
+        url "https://azuremarketplace.microsoft.com"
+    }
+    google-marketplace = softwareSystem "Google Cloud Marketplace" "Google Cloud Marketplace. Used for PAYG entitlement management and marketplace event consumption on GCP stacks." {
+        tags "Vendor"
+        url "https://cloud.google.com/marketplace"
+    }
+
+    # --- Customer storage backends ---
+    snowflake = softwareSystem "Snowflake" "Cloud data warehouse. Customer storage backend." {
+        tags "Vendor"
+        url "https://www.snowflake.com"
+    }
+    bigquery  = softwareSystem "Google BigQuery" "Serverless cloud data warehouse (GCP). Customer storage backend." {
+        tags "Vendor"
+        url "https://cloud.google.com/bigquery"
+    }
+    synapse   = softwareSystem "Azure Synapse Analytics" "Cloud analytics service (Azure). Legacy customer storage backend." {
+        tags "Vendor" "Legacy"
+        url "https://azure.microsoft.com/en-us/products/synapse-analytics"
+    }
+    exasol    = softwareSystem "Exasol" "In-memory analytics database. Legacy customer storage backend." {
+        tags "Vendor" "Legacy"
+        url "https://www.exasol.com"
+    }
+    supabase  = softwareSystem "Supabase" "Open-source Postgres platform. Uncommissioned customer storage backend (BYODB)." {
+        tags "Vendor" "Uncommissioned"
+        url "https://supabase.com"
+    }
+
+    # --- SaaS integrations ---
+    sendgrid = softwareSystem "SendGrid" "Email delivery service. Transactional emails (invitations, notifications, token sharing)." {
+        tags "Vendor"
+        url "https://sendgrid.com"
+    }
+    stripe   = softwareSystem "Stripe" "Payment processing platform. Pay-as-you-go credit purchases." {
+        tags "Vendor"
+        url "https://stripe.com"
+    }
+
+    # --- Kubernetes managed services ---
+    # Tagged "CloudResource" (not "Vendor"/"CloudProvider") so they can appear in L3 component views
+    # for services that make explicit application-level K8s API calls (pod management, CRD operations,
+    # resource watching). This is NOT the generic "runs-on" relationship shown at L1.
+    aws-eks   = softwareSystem "AWS EKS" "Managed Kubernetes (AWS). Referenced by services that explicitly call the K8s API at application level." {
+        tags "CloudResource" "AWS"
+    }
+    azure-aks = softwareSystem "Azure AKS" "Managed Kubernetes (Azure). Referenced by services that explicitly call the K8s API at application level." {
+        tags "CloudResource" "Azure"
+    }
+    gcp-gke   = softwareSystem "GCP GKE" "Managed Kubernetes (GCP). Referenced by services that explicitly call the K8s API at application level." {
+        tags "CloudResource" "GCP"
+    }

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service-external.dsl
@@ -1,0 +1,5 @@
+# Cloud resource relationships for git-service
+# Included at top level of model block in model.dsl
+#
+# No cloud resource relationships — git-service has no database, object storage,
+# KMS keys, or message queues.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service.dsl
@@ -1,0 +1,6 @@
+# L3 inter-service relationships for git-service
+# Included inside keboolaPlatform block in model.dsl
+# Not yet fully commissioned — no Terraform wiring exists yet.
+
+git-service-api -> connection "verifies tokens and reads project context via Manage API (GIT_SERVICE_MANAGE_API_URL)"
+git-service-api -> forgejo    "manages Git repositories via Forgejo admin token (GIT_SERVICE_FORGEJO_URL)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/git-service.md
@@ -1,0 +1,28 @@
+# git-service — dependency analysis
+
+## Deployed components
+
+- `git-service-api` (Deployment): Go REST API wrapping Forgejo. Serves at `git-service.{suffix}`.
+  Port 8082. Single Deployment; no CronJobs, no workers.
+  Source: `go-monorepo/services/git-service`. Not yet fully commissioned.
+
+## Inter-service dependencies
+
+- `git-service-api` -> `connection`: via `GIT_SERVICE_MANAGE_API_URL` (internal cluster URL
+  `http://connection-api.connection.svc.cluster.local`). Uses the Manage API to verify tokens
+  and read project/organization context.
+- `git-service-api` -> `forgejo`: via `GIT_SERVICE_FORGEJO_URL` (internal cluster URL
+  `http://forgejo-http.forgejo.svc.cluster.local:3000`). Manages Git repositories in the
+  self-hosted Forgejo instance using an admin token.
+
+## Named cloud resource dependencies
+
+None. No database, no object storage, no KMS, no message queues.
+
+## Notes
+
+- No Terraform module exists yet (`app_forgejo.tf` and `app_git_service.tf` absent from
+  `aws/stage-30/`). Confirms uncommissioned status.
+- `forgejo` is a self-hosted Git service deployed via the upstream Bitnami/Forgejo Helm chart
+  (v17). It is modelled as a separate `SelfHosted` container — like Elasticsearch — because it
+  is independently deployed and not co-located with git-service.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon-external.dsl
@@ -1,0 +1,39 @@
+# Cloud resource relationships for job-queue-daemon
+# Included at top level of model block in model.dsl
+
+# Shared job-runner KMS key -- used by daemon to decrypt job configuration injected into spawned pods
+queue-daemon-run             -> kms-key-job-runner-aws   "decrypts job configuration in spawned pods on AWS stacks"
+queue-daemon-run             -> kms-key-job-runner-azure "decrypts job configuration in spawned pods on Azure stacks"
+queue-daemon-run             -> kms-key-job-runner-gcp   "decrypts job configuration in spawned pods on GCP stacks"
+
+# MySQL
+queue-daemon-run             -> mysql-instance-job-queue "persists daemon state"
+queue-daemon-start           -> mysql-instance-job-queue "reads job records"
+queue-daemon-flow-transition -> mysql-instance-job-queue "updates flow job state"
+daemon-cron-db-cleanup       -> mysql-instance-job-queue "cleans up stale records"
+daemon-cron-flow-cleanup     -> mysql-instance-job-queue "removes stale flow job data"
+
+# K8s API (application-level -- spawning and cleaning up pods, all clouds)
+queue-daemon-run        -> aws-eks   "spawns job pods via Kubernetes API on AWS stacks"
+queue-daemon-run        -> azure-aks "spawns job pods via Kubernetes API on Azure stacks"
+queue-daemon-run        -> gcp-gke   "spawns job pods via Kubernetes API on GCP stacks"
+daemon-cron-pod-cleanup -> aws-eks   "cleans up orphaned pods via Kubernetes API on AWS stacks"
+daemon-cron-pod-cleanup -> azure-aks "cleans up orphaned pods via Kubernetes API on Azure stacks"
+daemon-cron-pod-cleanup -> gcp-gke   "cleans up orphaned pods via Kubernetes API on GCP stacks"
+
+# Daemon-owned internal queues (Pattern A -- daemon publishes and consumes)
+# jobs-to-start: daemon-run publishes, daemon-start consumes
+queue-daemon-run   -> sqs-queue-daemon-jobs-to-start          "publishes jobs-to-start on AWS stacks"
+queue-daemon-start -> sqs-queue-daemon-jobs-to-start          "consumes jobs-to-start on AWS stacks"
+queue-daemon-run   -> servicebus-queue-daemon-jobs-to-start   "publishes jobs-to-start on Azure stacks"
+queue-daemon-start -> servicebus-queue-daemon-jobs-to-start   "consumes jobs-to-start on Azure stacks"
+queue-daemon-run   -> pubsub-topic-daemon-jobs-to-start       "publishes jobs-to-start on GCP stacks"
+queue-daemon-start -> pubsub-topic-daemon-jobs-to-start       "consumes jobs-to-start on GCP stacks"
+
+# flow-jobs-transition: daemon-run publishes, daemon-flow-transition consumes
+queue-daemon-run             -> sqs-queue-daemon-flow-jobs-transition          "publishes flow-jobs-transition on AWS stacks"
+queue-daemon-flow-transition -> sqs-queue-daemon-flow-jobs-transition          "consumes flow-jobs-transition on AWS stacks"
+queue-daemon-run             -> servicebus-queue-daemon-flow-jobs-transition   "publishes flow-jobs-transition on Azure stacks"
+queue-daemon-flow-transition -> servicebus-queue-daemon-flow-jobs-transition   "consumes flow-jobs-transition on Azure stacks"
+queue-daemon-run             -> pubsub-topic-daemon-flow-jobs-transition       "publishes flow-jobs-transition on GCP stacks"
+queue-daemon-flow-transition -> pubsub-topic-daemon-flow-jobs-transition       "consumes flow-jobs-transition on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon.dsl
@@ -1,0 +1,29 @@
+# L3 inter-service relationships for job-queue-daemon
+# Included inside keboolaPlatform block in model.dsl
+
+# All daemon components call connection for token verification and project config
+queue-daemon-run             -> connection         "verifies tokens, reads project configs"
+queue-daemon-start           -> connection         "verifies tokens, reads project configs"
+queue-daemon-stop            -> connection         "verifies tokens"
+queue-daemon-flow-transition -> connection         "verifies tokens"
+
+# Internal queue API — all active daemon processes poll/update job state
+queue-daemon-run             -> queue-internal-api "polls for jobs to start, updates job state"
+queue-daemon-start           -> queue-internal-api "processes jobs-to-start messages"
+queue-daemon-stop            -> queue-internal-api "updates stopping job state"
+queue-daemon-flow-transition -> queue-internal-api "processes flow job transitions"
+
+# Notification — daemon pushes job events
+queue-daemon-run             -> notification       "pushes job lifecycle events"
+queue-daemon-stop            -> notification       "pushes job stop events"
+
+# Billing — daemon records job usage
+queue-daemon-run             -> billing            "records job usage for billing"
+
+# Vault — daemon resolves variables for job pods
+queue-daemon-run             -> vault              "resolves variables for job execution"
+queue-daemon-start           -> vault              "resolves variables for job execution"
+
+# CronJobs
+daemon-cron-db-cleanup       -> queue-internal-api "cleans up stale DB records"
+daemon-cron-flow-cleanup     -> queue-internal-api "removes stale flow job data"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-daemon.md
@@ -1,0 +1,39 @@
+# job-queue-daemon — dependency analysis
+
+## Deployed components (data-driven from values.yaml)
+
+### Deployments
+- `queue-daemon-run` (Deployment): command `app:run` — main daemon loop
+- `queue-daemon-start` (Deployment): command `messenger:consume jobsToStart`
+- `queue-daemon-stop` (Deployment): command `app:stop` — graceful job stopping
+- `queue-daemon-flow-transition` (Deployment): command `messenger:consume flowJobsTransition`
+
+### CronJobs
+- `daemon-cron-pod-cleanup` (CronJob, every 10min): cleans up orphaned K8s pods via Kubernetes API
+- `daemon-cron-db-cleanup` (CronJob, every hour): cleans up stale DB records
+- `daemon-cron-flow-cleanup` (CronJob, every 30min): removes stale flow job data
+
+## Inter-service dependencies
+- All daemon deployments -> `connection`: `STORAGE_API_URL_INTERNAL` via `Keboola\StorageApiBranch` and `Keboola\ManageApi\Client`
+- All daemon deployments -> `queue-internal-api`: `DAEMON_INTERNAL_QUEUE_API_URL` via `Keboola\JobQueueInternalClient\Client`
+- `queue-daemon-run` + `queue-daemon-stop` -> `notification`: `Keboola\NotificationClient\ClientFactory`
+- `queue-daemon-run` -> `billing`: `Keboola\BillingApi\ClientFactory` (conditional on `BILLING_ENABLED`)
+- `queue-daemon-run` + `queue-daemon-start` -> `vault`: `VAULT_API_URL` in `App\Daemon\RunnerConfigurationFactory`
+- `daemon-cron-db-cleanup` -> `queue-internal-api`: cleans up internal API DB records
+- `daemon-cron-flow-cleanup` -> `queue-internal-api`: removes stale flow job data
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, vault, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_job_queue_daemon.tf |
+| `kms-key-job-runner-aws` | KMS key (AWS) | encryption-api, queue-runner, sync-actions | `job_runner_kms_arn = local.job_runner_kms_arn` in app_job_queue_daemon.tf |
+| `kms-key-job-runner-azure` | Key Vault key (Azure) | encryption-api, queue-runner, sync-actions | `azure_key_vault_url` in azure/main.tf |
+| `kms-key-job-runner-gcp` | Cloud KMS key (GCP) | encryption-api, queue-runner, sync-actions | `GCP_KMS_KEY_ID` in gcp/main.tf |
+
+## Unresolved
+None.
+
+## Notes
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in all cloud variants — deprecated ECR auth credentials. Not an AWS storage dependency.
+- `RUNNER_INTERNAL_QUEUE_API_URL` in `K8sManifestsFactory` is configuration injected into spawned job pods — NOT a direct daemon dependency.
+- `daemon-cron-pod-cleanup` calls the Kubernetes API directly to clean up orphaned pods. This is an application-level K8s dependency modelled in `-external.dsl`.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue-external.dsl
@@ -1,0 +1,22 @@
+# Cloud resource relationships for job-queue
+# Included at top level of model block in model.dsl
+
+# Public API -- uses shared job-runner KMS key for token decryption
+queue-public-api   -> kms-key-job-runner-aws   "decrypts job configuration on AWS stacks"
+queue-public-api   -> kms-key-job-runner-azure "decrypts job configuration on Azure stacks"
+queue-public-api   -> kms-key-job-runner-gcp   "decrypts job configuration on GCP stacks"
+
+# Internal API group
+queue-internal-api -> mysql-instance-job-queue "persists job data"
+queue-logstash     -> mysql-instance-job-queue "reads job data for replication to Elasticsearch"
+queue-cleanup      -> mysql-instance-job-queue "deletes job records for purged projects"
+queue-purge        -> mysql-instance-job-queue "purges old job records"
+queue-replication-check -> mysql-instance-job-queue "checks DB replication state"
+
+# Runner group -- uses shared job-runner KMS key
+queue-runner     -> kms-key-job-runner-aws   "decrypts job configuration on AWS stacks"
+queue-runner     -> kms-key-job-runner-azure "decrypts job configuration on Azure stacks"
+queue-runner     -> kms-key-job-runner-gcp   "decrypts job configuration on GCP stacks"
+queue-job-runner -> kms-key-job-runner-aws   "decrypts job configuration on AWS stacks (legacy)"
+queue-job-runner -> kms-key-job-runner-azure "decrypts job configuration on Azure stacks (legacy)"
+queue-job-runner -> kms-key-job-runner-gcp   "decrypts job configuration on GCP stacks (legacy)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue.dsl
@@ -1,0 +1,34 @@
+# L3 inter-service relationships for job-queue
+# Included inside keboolaPlatform block in model.dsl
+
+# queue-public-api is the only external-facing component
+queue-public-api -> connection          "verifies tokens, reads component configs"
+
+# queue-internal-api group
+queue-internal-api -> connection        "verifies tokens via Storage API"
+queue-cleanup      -> connection        "verifies tokens"
+queue-purge        -> connection        "verifies tokens"
+queue-replication-check -> connection   "verifies tokens"
+
+# queue-runner (job execution components)
+# Note: queue-runner is ephemeral — it runs inside a per-job K8s pod spawned by the daemon
+# and exits when the job completes. It is modelled as a component for relationship clarity,
+# not because it is a long-running deployed service.
+queue-runner -> connection             "reads job config and storage data"
+queue-runner -> vault                  "resolves variables before job execution"
+
+# queue-gelf-logger
+queue-gelf-logger -> connection        "writes job logs to Storage"
+
+# queue-job-runner (legacy)
+queue-job-runner -> connection         "reads job config and storage data"
+queue-job-runner -> queue-internal-api "updates job state"
+queue-job-runner -> vault              "resolves variables before job execution"
+
+# internal wiring — public-api calls internal-api (same container, not cross-container)
+queue-public-api -> queue-internal-api "creates and queries jobs (internal)"
+
+# logstash replicates DB to Elasticsearch
+queue-logstash -> job-queue-elasticsearch        "replicates job records for search"
+queue-internal-api -> job-queue-elasticsearch    "indexes and searches jobs"
+queue-replication-check -> job-queue-elasticsearch "checks replication lag"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/job-queue.md
@@ -1,0 +1,54 @@
+# job-queue — dependency analysis
+
+## Deployed components
+
+### Group 1 — Public API
+- `queue-public-api` (Deployment): sole external-facing component
+
+### Group 2 — Internal API
+- `queue-internal-api` (Deployment): PHP REST API, internal only
+- `queue-logstash` (Logstash CRD): replicates MySQL to Elasticsearch
+- `queue-cleanup` (CronJob, every 12h): deletes jobs for purged projects
+- `queue-purge` (CronJob, every 3h): purges old job records
+- `queue-replication-check` (CronJob, every 15min): verifies DB to Elasticsearch replication
+
+### Group 3 — Runner (ephemeral per-job pods)
+- `queue-runner`: service-container + input-mapping + output-mapping (spawned per job)
+- `queue-gelf-logger`: GELF log collector sidecar
+- `queue-job-runner` (Legacy): monolithic predecessor to the above runner sub-components
+
+### Group 4 — Daemon
+- Scanned separately as `job-queue-daemon`. See job-queue-daemon.md.
+
+## Inter-service dependencies
+- `queue-public-api` -> `connection`: `STORAGE_API_URL` + `Keboola\StorageApiBranch` + `Keboola\ManageApi\Client`
+- `queue-public-api` -> `queue-internal-api`: `INTERNAL_API_URL` — internal wiring within `queue` container, not cross-container
+- `queue-internal-api` -> `connection`: `ServiceClient.getConnectionServiceUrl()`
+- `queue-internal-api` -> `elasticsearch`: `ELASTICSEARCH_URL` (self-hosted container)
+- `queue-logstash` -> `elasticsearch`: output plugin replicates from MySQL
+- `queue-replication-check` -> `elasticsearch`: checks replication lag
+- `queue-runner` -> `connection`: `Keboola\StorageApiBranch` in service-container/services.yaml
+- `queue-runner` -> `vault`: `Keboola\VaultApiClient` in service-container/services.yaml
+- `queue-gelf-logger` -> `connection`: `STORAGE_API_URL` in gelf-logger-server/services.yaml
+- `queue-job-runner` -> `connection`: `STORAGE_API_URL` via `Keboola\StorageApiBranch` (legacy)
+- `queue-job-runner` -> `queue-internal-api`: `JOB_QUEUE_URL` via `Keboola\JobQueueInternalClient\Client` (legacy)
+- `queue-job-runner` -> `vault`: `VAULT_API_URL` via `Keboola\VaultApiClient` (legacy)
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | editor, scheduler, vault, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_job_queue_internal_api.tf |
+| `kms-key-job-runner-aws` | KMS key (AWS) | encryption-api, job-queue-daemon, sync-actions | `job_runner_kms_key_id` in app-job-queue-public-api/aws/main.tf; injected into runner pods by daemon |
+| `kms-key-job-runner-azure` | Key Vault key (Azure) | encryption-api, job-queue-daemon, sync-actions | `azure_key_vault_url` in app-job-queue-public-api/azure/main.tf |
+| `kms-key-job-runner-gcp` | Cloud KMS key (GCP) | encryption-api, job-queue-daemon, sync-actions | `GCP_KMS_KEY_ID` in app-job-queue-public-api/gcp/main.tf |
+
+## Self-hosted infrastructure
+| Resource | Evidence |
+|---|---|
+| `elasticsearch` | `ELASTICSEARCH_URL` in internal-api/services.yaml; `ELASTICSEARCH_USER/PASSWORD` in app-job-queue-internal-api/aws/main.tf |
+
+## Unresolved
+None.
+
+## Notes
+- `queue-runner` KMS credentials are injected by the daemon at pod spawn time via `RunnerConfigurationFactory`, not self-provisioned. The dependency is real even though the runner does not configure it directly.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant-external.dsl
@@ -1,0 +1,39 @@
+# Cloud resource relationships for kai-assistant
+# Included at top level of model block in model.dsl
+# Covers three deployed apps: kai-app-ai-chat, kai-app-kai-assistant, kai-app-kai-agent
+
+# PostgreSQL -- shared instance, separate database per app
+kai-app-ai-chat       -> postgresql-instance "persists chat history and app data (ai_chat database)"
+kai-app-kai-assistant -> postgresql-instance "persists conversation history and app data (kai_assistant database)"
+kai-app-kai-agent     -> postgresql-instance "persists agent run history and app data (kai_agent database)"
+
+# Object storage -- service-owned per-app buckets (same resource IDs used for all three apps)
+kai-app-ai-chat       -> s3-bucket-ai-chat-storage  "stores uploaded files and artifacts on AWS stacks"
+kai-app-ai-chat       -> abs-ai-chat-storage         "stores uploaded files and artifacts on Azure stacks"
+kai-app-ai-chat       -> gcs-ai-chat-storage         "stores uploaded files and artifacts on GCP stacks"
+
+kai-app-kai-assistant -> s3-bucket-ai-chat-storage  "stores uploaded files and artifacts on AWS stacks"
+kai-app-kai-assistant -> abs-ai-chat-storage         "stores uploaded files and artifacts on Azure stacks"
+kai-app-kai-assistant -> gcs-ai-chat-storage         "stores uploaded files and artifacts on GCP stacks"
+
+kai-app-kai-agent     -> s3-bucket-ai-chat-storage  "stores agent artifacts and code outputs on AWS stacks"
+kai-app-kai-agent     -> abs-ai-chat-storage         "stores agent artifacts and code outputs on Azure stacks"
+kai-app-kai-agent     -> gcs-ai-chat-storage         "stores agent artifacts and code outputs on GCP stacks"
+
+# GCP KMS -- used only to encrypt GCS buckets at rest (GCP stacks only, no AWS/Azure equivalent)
+kai-app-ai-chat       -> kms-key-ai-chat-gcp        "GCS bucket encrypted with service-owned KMS key on GCP stacks"
+kai-app-kai-assistant -> kms-key-ai-chat-gcp        "GCS bucket encrypted with service-owned KMS key on GCP stacks"
+kai-app-kai-agent     -> kms-key-ai-chat-gcp        "GCS bucket encrypted with service-owned KMS key on GCP stacks"
+
+# Cloud LLM -- provider varies by cloud stack (Vertex on AWS+GCP, Azure AI Foundry on Azure)
+kai-app-ai-chat       -> google-vertex-ai   "calls Claude model via Vertex AI on AWS and GCP stacks"
+kai-app-ai-chat       -> azure-ai-foundry   "calls Claude model via Azure AI Foundry on Azure stacks"
+
+kai-app-kai-assistant -> google-vertex-ai   "calls Claude model via Vertex AI on AWS and GCP stacks"
+kai-app-kai-assistant -> azure-ai-foundry   "calls Claude model via Azure AI Foundry on Azure stacks"
+
+kai-app-kai-agent     -> google-vertex-ai   "calls Claude model via Vertex AI on AWS and GCP stacks"
+kai-app-kai-agent     -> azure-ai-foundry   "calls Claude model via Azure AI Foundry on Azure stacks"
+
+# E2B -- kai-agent only
+kai-app-kai-agent     -> e2b               "executes sandboxed Python/JS code via E2B code interpreter"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant.dsl
@@ -1,0 +1,13 @@
+# L3 inter-service relationships for kai-assistant
+# Included inside keboolaPlatform block in model.dsl
+# Covers three deployed apps: kai-app-ai-chat, kai-app-kai-assistant, kai-app-kai-agent
+# All use the same app-ai-chat Terraform module with different namespace values.
+
+kai-app-ai-chat       -> connection        "authenticates users via Keboola OAuth, refreshes OAuth tokens, reads Storage API data"
+kai-app-ai-chat       -> mcp-server-agent  "calls platform tools via MCP (MCP_SERVER_URL = mcp-agent.{suffix})"
+
+kai-app-kai-assistant -> connection        "verifies Storage API tokens and reads Storage data"
+kai-app-kai-assistant -> mcp-server-agent  "calls platform tools via MCP (MCP_SERVER_URL = mcp-agent.{suffix})"
+
+kai-app-kai-agent     -> connection        "verifies Storage API tokens and reads Storage data"
+kai-app-kai-agent     -> mcp-server-agent  "calls platform tools via MCP (MCP_SERVER_URL = mcp-agent.{suffix})"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/kai-assistant.md
@@ -1,0 +1,92 @@
+# kai-assistant — dependency analysis
+
+## Deployed components
+
+Three independently deployed apps, all using the same `app-ai-chat` Terraform module
+(namespace variable distinguishes them):
+
+- `kai-app-ai-chat` (Deployment): Next.js read-only chat app. Hosted at `ai-chat.{suffix}`.
+  Uses Keboola OAuth (KEBOOLA_OAUTH_CLIENT_ID/SECRET) for authentication.
+  Repo: `keboola/ai-chat`.
+
+- `kai-app-kai-assistant` (Deployment): Next.js BFF backend for the KAI Assistant chat UI.
+  Hosted at `kai-assistant.{suffix}`. No OAuth — callers pass Storage token directly.
+  Repo: `keboola/ui` (`apps/kai-assistant-backend`).
+
+- `kai-app-kai-agent` (Deployment): Hono HTTP server (not Next.js). Agentic code executor
+  with sandboxed code execution via E2B. Hosted at `kai-agent.{suffix}`.
+  Repo: `keboola/ui` (`apps/kai-agent`).
+
+All three have a database-migration Helm hook Job (skipped as C4 component — deploy-time only).
+
+## Inter-service dependencies (all three apps)
+
+- All three -> `connection`: via `KEBOOLA_OAUTH_HOST` / `KEBOOLA_STORAGE_API_URL` /
+  `NEXT_PUBLIC_KEBOOLA_URL`. Used for token auth and Storage API calls.
+- All three -> `mcp-server-agent`: via `MCP_SERVER_URL` = `https://mcp-agent.{suffix}/mcp`.
+  Calls the internal MCP server agent (streamable-http transport).
+
+### kai-agent only
+
+- `kai-app-kai-agent` -> E2B: via `E2B_API_KEY`. Sandboxed Python/JS code execution.
+
+## Cloud LLM provider — cloud-dependent (not modelled per-component)
+
+All three apps use a cloud LLM for Claude. Provider varies by cloud stack:
+- AWS + GCP: Google Vertex AI (`GOOGLE_SERVICE_ACCOUNT_JSON`, `GOOGLE_VERTEX_LOCATION`,
+  `GOOGLE_VERTEX_PROJECT`)
+- Azure: Azure AI Foundry (`FOUNDRY_API_ENDPOINT`, `FOUNDRY_API_KEY`,
+  `FOUNDRY_DEPLOYMENT_NAME`, `FOUNDRY_MODEL_NAME`). Toggled via `CLOUD_LLM_PROVIDER`.
+
+Modelled as two separate named resources in `-external.dsl`.
+
+## Named cloud resource dependencies
+
+All three apps use the **same** Terraform module (`app-ai-chat`) reused with different
+`namespace` values. Each app gets its own database and object storage bucket but shares
+the same PostgreSQL RDS instance (separate databases).
+
+| Resource ID | Type | Evidence |
+|---|---|---|
+| `rds-postgresql` | Shared PostgreSQL RDS instance | `module.postgresql[0].master_db_instance_address` in `rds_postgresql.tf`. All three apps get separate databases (`ai_chat`, `kai_assistant`, `kai_agent`) on the same RDS instance. |
+| `s3-bucket-ai-chat-storage` | S3 bucket (AWS, per-app) | `aws_s3_bucket.ai_chat_storage` in aws/s3.tf. Three separate buckets, one per app namespace. |
+| `abs-ai-chat-storage` | Azure Blob Storage account (Azure, per-app) | `azurerm_storage_account.ai_chat_storage` in azure/azure.tf. Three separate storage accounts. |
+| `gcs-ai-chat-storage` | GCS bucket (GCP, per-app) | `google_storage_bucket.ai_chat_storage` in gcp/main.tf. Three separate buckets. |
+| `kms-key-ai-chat-gcp` | GCP Cloud KMS key (GCP only) | `google_kms_crypto_key.ai_chat_encryption` in gcp/main.tf. Used to encrypt GCS buckets. No equivalent KMS on AWS or Azure. |
+| `google-vertex-ai` | Google Vertex AI (AWS + GCP stacks) | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_SERVICE_ACCOUNT_JSON`, `GOOGLE_VERTEX_LOCATION`. Claude model via Vertex. |
+| `azure-ai-foundry` | Azure AI Foundry (Azure stacks) | `FOUNDRY_API_ENDPOINT`, `FOUNDRY_API_KEY`, `FOUNDRY_DEPLOYMENT_NAME`. Claude model via Azure AI Foundry. |
+| `e2b` | E2B sandboxed code execution | `E2B_API_KEY` in kai-agent secret.yaml. `@e2b/code-interpreter` in kai-agent package.json. |
+
+## New resources added to cloud-resources.dsl
+
+- `rds-postgresql`: Shared PostgreSQL RDS instance (AWS)
+- `s3-bucket-ai-chat-storage`: S3 bucket for KAI app object storage (AWS)
+- `abs-ai-chat-storage`: Azure Blob Storage account for KAI app object storage (Azure)
+- `gcs-ai-chat-storage`: GCS bucket for KAI app object storage (GCP)
+- `kms-key-ai-chat-gcp`: GCP Cloud KMS key for GCS bucket encryption (GCP only)
+- `google-vertex-ai`: Google Vertex AI (external SaaS — Claude via Vertex, AWS + GCP stacks)
+- `azure-ai-foundry`: Azure AI Foundry (external SaaS — Claude via Foundry, Azure stacks)
+- `e2b`: E2B sandboxed code execution (external SaaS)
+
+## Unresolved
+
+- **Redis**: `redis` package present in both `ai-chat` and `kai-assistant-backend`
+  `package.json`, but NOT wired up in any Terraform infra secrets or kbc-stacks secrets.
+  Likely dev-only or future dependency. Not modelled.
+
+## Notes
+
+- All three apps are deployed using the same Terraform module `app-ai-chat/aws|azure|gcp`
+  with different `namespace` values (`ai-chat`, `kai-assistant`, `kai-agent`). This is why
+  there is no separate `app-kai-assistant` or `app-kai-agent` Terraform module.
+- `kai-app-ai-chat` uses Keboola OAuth (has `KEBOOLA_OAUTH_CLIENT_ID/SECRET`).
+  The other two use direct Storage token auth (no OAuth credentials).
+- `kai-app-kai-agent` is a Hono server, not Next.js — different framework from the other two.
+- GCP KMS key is used only to encrypt GCS bucket at rest (not application-level encryption).
+  Per project conventions this is storage-level encryption — borderline for C4 modelling.
+  Included for completeness since it's a service-owned named resource.
+- Object storage (S3/ABS/GCS) is used for application file storage (uploads, artifacts).
+  Three separate buckets per cloud — one per app. Modelled as shared resource IDs since
+  all three apps use the same storage pattern.
+- LangSmith (`LANGCHAIN_API_KEY` / `LANGSMITH_API_KEY`) is a tracing/observability tool
+  similar to Datadog — not modelled as a C4 dependency.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server-external.dsl
@@ -1,0 +1,4 @@
+# Cloud resource relationships for mcp-server
+# Included at top level of model block in model.dsl
+# mcp-server has no cloud resource dependencies of its own.
+# (No Terraform module, no KMS, no database, no queues, no object storage.)

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server.dsl
@@ -1,0 +1,28 @@
+# L3 inter-service relationships for mcp-server
+# Included inside keboolaPlatform block in model.dsl
+# All service URLs derived at runtime from storage_api_url via hostname suffix substitution.
+# Source: KeboolaClient.__init__ in src/keboola_mcp_server/clients/client.py
+# Note: component IDs are mcp-server-api and mcp-server-agent (not mcp-server)
+# to avoid clashing with the container ID mcp-server.
+
+mcp-server-api   -> connection   "verifies tokens, reads Storage API data (buckets, tables, files, configurations, workspaces)"
+mcp-server-api   -> queue        "creates and monitors component jobs"
+mcp-server-api   -> ai           "accesses AI features (AI API)"
+mcp-server-api   -> encryption   "encrypts and decrypts configuration values"
+mcp-server-api   -> scheduler    "manages scheduled configurations"
+mcp-server-api   -> sync-actions "executes synchronous component actions"
+mcp-server-api   -> query        "executes SQL queries on Snowflake workspaces"
+mcp-server-api   -> metastore    "reads metadata and lineage information"
+mcp-server-api   -> sandboxes    "manages Data Apps via Data Science API (data-science.{suffix})"
+
+mcp-server-agent -> connection   "verifies tokens, reads Storage API data"
+mcp-server-agent -> queue        "creates and monitors component jobs"
+mcp-server-agent -> ai           "accesses AI features"
+mcp-server-agent -> encryption   "encrypts and decrypts configuration values"
+mcp-server-agent -> scheduler    "manages scheduled configurations"
+mcp-server-agent -> sync-actions "executes synchronous component actions"
+mcp-server-agent -> query        "executes SQL queries on Snowflake workspaces"
+mcp-server-agent -> metastore    "reads metadata and lineage information"
+mcp-server-agent -> sandboxes    "manages Data Apps via Data Science API"
+
+kai-assistant    -> mcp-server-agent "calls platform tools via MCP (streamable-http transport)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/mcp-server.md
@@ -1,0 +1,47 @@
+# mcp-server — dependency analysis
+
+## Deployed components
+- `mcp-server` (Deployment, namespace `mcp-server`): Public-facing FastMCP server.
+  OAuth-authenticated (KBC_OAUTH_CLIENT_ID/SECRET/JWT_SECRET). Transport: `http-compat`.
+  Serves external AI agents (Cursor, Claude Desktop, Windsurf, etc.).
+
+- `mcp-server-agent` (Deployment, namespace `mcp-server-agent`, 2 replicas): Internal FastMCP
+  server. Same image (`keboola/mcp-server`), dedicated endpoint for kai-assistant.
+  Transport: `streamable-http`. No OAuth secrets — caller (kai-assistant) passes Storage
+  token directly. Deployed from kbc-stacks `apps/mcp-server-agent/`.
+
+## Inter-service dependencies
+All service URLs are derived at runtime in `KeboolaClient.__init__` by substituting
+the `connection.` prefix in `storage_api_url`. Both `mcp-server` and `mcp-server-agent`
+have identical service dependencies — same `KeboolaClient` code path, same set of APIs.
+No service URLs appear in ENV or infra_secrets — invisible to ENV scanning.
+
+| Target container | URL derivation |
+|---|---|
+| `connection` | `connection.{suffix}` via `AsyncStorageClient` |
+| `queue` | `queue.{suffix}` via `JobsQueueClient` |
+| `ai` | `ai.{suffix}` via `AIServiceClient` |
+| `encryption` | `encryption.{suffix}` via `EncryptionClient` |
+| `scheduler` | `scheduler.{suffix}` via `SchedulerClient` |
+| `sync-actions` | `sync-actions.{suffix}` via `SyncActionsClient` |
+| `query` | `query.{suffix}` via `QueryServiceClient` (in `workspace.py`) |
+| `metastore` | `metastore.{suffix}` via `MetastoreClient` |
+| `sandboxes` | `data-science.{suffix}` via `DataScienceClient` (Data Apps API) |
+
+`kai-assistant` -> `mcp-server-agent`: kai-assistant calls mcp-server-agent as its
+MCP tool provider (streamable-http transport).
+
+## Named cloud resource dependencies
+None. No Terraform module for either deployment.
+
+## Unresolved
+None.
+
+## Notes
+- `mcp-server` and `mcp-server-agent` are the same Docker image deployed twice with
+  different CLI args (`--transport http-compat` vs `--transport streamable-http`),
+  different namespaces, and different auth models (OAuth vs direct token).
+- `data-science.{suffix}` is the Data Science / Data Apps API served by `sandboxes-service`,
+  NOT a separate container.
+- `KBC_OAUTH_CLIENT_ID/SECRET/JWT_SECRET` in `mcp-server` only — OAuth credentials for
+  authenticating external users. `mcp-server-agent` has no OAuth secrets.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service-external.dsl
@@ -1,0 +1,4 @@
+# Cloud resource relationships for metastore-service
+# Included at top level of model block in model.dsl
+
+metastore-api -> postgresql-instance "persists metadata objects and refs (metastore_service database)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for metastore-service
+# Included inside keboolaPlatform block in model.dsl
+# Gated on var.metastore_enabled — implemented but not yet enabled on production stacks.
+
+metastore-api -> connection "verifies tokens and reads project context via Storage API (METASTORE_STORAGE_API_HOST)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/metastore-service.md
@@ -1,0 +1,29 @@
+# metastore-service — dependency analysis
+
+## Deployed components
+
+- `metastore-api` (Deployment): Go REST API. Serves at `metastore.{suffix}`. Port 8000.
+  Source: `go-monorepo/services/metastore`. Terraform exists (`app_metastore.tf`) but
+  gated on `var.metastore_enabled` — implemented but not yet enabled on production stacks.
+
+## Inter-service dependencies
+
+- `metastore-api` -> `connection`: via `METASTORE_STORAGE_API_HOST = connection.{suffix}`.
+  Used by `PublicScope` (services map) and `ProjectScope` (per-request token verification
+  and project context resolution via Storage API).
+
+## Named cloud resource dependencies
+
+| Resource ID | Type | Evidence |
+|---|---|---|
+| `rds-postgresql` | Shared PostgreSQL RDS | `METASTORE_DB_*` injected from `kubernetes-postgresql-init` module; same shared RDS instance as query-service and kai-assistant apps. Database: `metastore_service`. |
+
+## Notes
+
+- Same Terraform pattern as query-service: single module variant (no aws/azure/gcp split),
+  PostgreSQL credentials only, no cloud-specific resources.
+- No KMS, no message queues, no object storage.
+- `job-migrate` Job is a helm hook (pre-install/pre-upgrade) — deploy-time only, skipped.
+- The service is fully implemented with migrations, repository layer, authz, and API;
+  it is "uncommissioned" only in the sense that `metastore_enabled` defaults to false
+  in production stack variables.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service-external.dsl
@@ -1,0 +1,18 @@
+# Cloud resource relationships for notification-service
+# Included at top level of model block in model.dsl
+
+# MySQL — shared job-queue instance
+notification-api                -> mysql-instance-job-queue "persists subscriptions and notifications"
+notification-messenger-consumer -> mysql-instance-job-queue "reads and updates notifications"
+notification-expired-subscription-pruning -> mysql-instance-job-queue "soft-deletes expired subscriptions"
+
+# Internal Messenger transport — service-owned queue per cloud (api publishes, consumer reads)
+notification-api                -> sqs-queue-notification-messages         "publishes notification messages on AWS stacks"
+notification-messenger-consumer -> sqs-queue-notification-messages         "consumes notification messages on AWS stacks"
+notification-api                -> servicebus-queue-notification-messages   "publishes notification messages on Azure stacks"
+notification-messenger-consumer -> servicebus-queue-notification-messages   "consumes notification messages on Azure stacks"
+notification-api                -> pubsub-topic-notification-messages       "publishes notification messages on GCP stacks"
+notification-messenger-consumer -> pubsub-topic-notification-messages       "consumes notification messages on GCP stacks"
+
+# Email delivery
+notification-messenger-consumer -> sendgrid "delivers email notifications via Symfony Mailer SendGrid transport"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for notification-service
+# Included inside keboolaPlatform block in model.dsl
+
+notification-api                -> connection "verifies tokens and reads project/org data via Storage and Manage APIs"
+notification-messenger-consumer -> connection "verifies tokens"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/notification-service.md
@@ -1,0 +1,26 @@
+# notification-service — dependency analysis
+
+## Deployed components
+- `notification-api` (Deployment): PHP Symfony REST API — accepts events and subscription management requests, publishes onto internal Messenger transport
+- `notification-messenger-consumer` (Deployment): command `messenger:consume notifications` — processes Event messages (matches subscriptions) and NotificationMessage (delivers via SendGrid or customer webhook)
+- `notification-expired-subscription-pruning` (CronJob, every 10 min): command `app:expire-subscriptions` — soft-deletes expired project subscriptions
+
+## Inter-service dependencies
+- `notification-api` -> `connection`: `getConnectionServiceUrl()` via `ServiceClient` in `ManageApiClientFactory`, `StorageApiBranch\Factory\ClientOptions`, and `StorageApiIndexClient` in services.yaml
+- `notification-messenger-consumer` -> `connection`: token verification
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, vault, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_notification_service.tf |
+| `sqs-queue-notification-messages` | SQS queue (AWS) | — (service-owned) | `aws_sqs_queue.messages` in aws/queue.tf; `MESSENGER_TRANSPORT_DSN` = SQS URL in aws/infra_secrets.tf |
+| `servicebus-queue-notification-messages` | Service Bus queue (Azure) | — (service-owned) | `azurerm_servicebus_queue.notification_service_messages` in azure module; `MESSENGER_TRANSPORT_DSN` = Service Bus DSN in azure/infra_secrets.tf |
+| `pubsub-topic-notification-messages` | Pub/Sub topic+subscription (GCP) | — (service-owned) | `google_pubsub_topic/subscription.notification_service_messages_queue` in gcp/main.tf; `MESSENGER_TRANSPORT_DSN` = Pub/Sub DSN |
+
+## Unresolved
+None.
+
+## Notes
+- The `MESSENGER_TRANSPORT_DSN` in all three cloud variants points to a **service-owned** queue — notification creates its own queue on each cloud. This is NOT a subscription to Connection events. The API publishes to this queue; the consumer reads from it. This is internal Symfony Messenger wiring.
+- `sendgrid` is used for email delivery by the messenger consumer — modelled as a Vendor relationship in `-external.dsl`.
+- No KMS/Key Vault dependency — notification does not use `Keboola\ObjectEncryptor`.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service-external.dsl
@@ -1,0 +1,21 @@
+# Cloud resource relationships for oauth-service
+# Included at top level of model block in model.dsl
+
+# MySQL -- shares job-queue instance
+oauth-service-api                                  -> mysql-instance-job-queue "persists OAuth credentials, sessions, and consumers"
+oauth-service-messenger-consumer-connection-events -> mysql-instance-job-queue "deletes OAuth sessions on devBranchDeleted events"
+oauth-service-session-expiration                   -> mysql-instance-job-queue "expires old auth sessions (every 15 min)"
+
+# Service-owned KMS keys (ObjectEncryptor for credential encryption)
+oauth-service-api                                  -> kms-key-oauth-aws   "encrypts and decrypts OAuth credentials on AWS stacks"
+oauth-service-api                                  -> kms-key-oauth-azure "encrypts and decrypts OAuth credentials on Azure stacks"
+oauth-service-api                                  -> kms-key-oauth-gcp   "encrypts and decrypts OAuth credentials on GCP stacks"
+
+# Pattern B -- fan-out subscriptions from Connection events topics
+oauth-service-messenger-consumer-connection-events -> sqs-queue-oauth-connection-events          "consumes devBranchDeleted events on AWS stacks"
+oauth-service-messenger-consumer-connection-events -> servicebus-queue-oauth-connection-events   "consumes devBranchDeleted events on Azure stacks"
+oauth-service-messenger-consumer-connection-events -> pubsub-sub-oauth-connection-events         "consumes devBranchDeleted events on GCP stacks"
+
+sqs-queue-oauth-connection-events          -> sns-topic-connection-events        "subscribed via aws_sns_topic_subscription (filtered: devBranchDeleted)"
+servicebus-queue-oauth-connection-events   -> eventgrid-topic-connection-events  "subscribed via azurerm_eventgrid_event_subscription (filtered: devBranchDeleted)"
+pubsub-sub-oauth-connection-events         -> pubsub-topic-connection-events     "subscribed via google_pubsub_subscription (filtered: devBranchDeleted)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for oauth-service
+# Included inside keboolaPlatform block in model.dsl
+
+oauth-service-api                                        -> connection "verifies tokens via Storage API; reads project and org data"
+oauth-service-messenger-consumer-connection-events       -> connection "receives devBranchDeleted events published by Connection (async)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/oauth-service.md
@@ -1,0 +1,33 @@
+# oauth-service — dependency analysis
+
+## Deployed components
+- `oauth-service-api` (Deployment): PHP Symfony REST API. OAuth credentials broker — stores, encrypts, and serves OAuth credentials to authorized platform services.
+- `oauth-service-messenger-consumer-connection-events` (Deployment): command `messenger:consume connection_events` — listens for `devBranchDeleted` events and purges associated OAuth sessions from the local DB. Pattern B fan-out subscription.
+- `oauth-service-session-expiration` (CronJob, every 15 min): command `app:expire-auth-sessions` — soft-expires old authentication sessions.
+- `oauth-service-serverless-proxy` (Deployment, conditional via `.Values.serverlessProxy.enabled`): nginx reverse proxy to serverless OAuth target. Infrastructure routing detail — not modelled as a C4 component.
+
+## Skipped (helm hooks)
+- `oauth-service-db-migration` (Job, `helm.sh/hook: pre-install,pre-upgrade`) — deploy-time DB migration
+- `oauth-service-legacy-oauth-migration` (Job, `helm.sh/hook: post-install,post-upgrade`) — deploy-time legacy data migration
+
+## Inter-service dependencies
+- `oauth-service-api` -> `connection`: `Keboola\StorageApiBranch\Factory\ClientOptions` using `STORAGE_API_URL` — token verification and project data
+- `oauth-service-messenger-consumer-connection-events` -> `connection`: receives `devBranchDeleted` events published by Connection (async, via cloud queue transport)
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, vault, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_oauth_service.tf |
+| `kms-key-oauth-aws` | KMS key (AWS) | — (service-owned) | `aws_kms_key.oauth_service` in aws/kms.tf; `AWS_KMS_KEY_ID = aws_kms_key.oauth_service.id` |
+| `kms-key-oauth-azure` | Key Vault (Azure) | — (service-owned) | `azurerm_key_vault.oauth_service` in azure/keyvault.tf; `AZURE_KEY_VAULT_URL` |
+| `kms-key-oauth-gcp` | Cloud KMS key (GCP) | — (service-owned) | `google_kms_crypto_key.oauth_service_encryption` in gcp/main.tf; `GCP_KMS_KEY_ID` |
+| `sqs-queue-oauth-connection-events` | SQS queue (AWS) | — (oauth-owned) | `aws_sqs_queue.connection_events` + `aws_sns_topic_subscription` in aws/queue.tf; filtered to `storage.devBranchDeleted` |
+| `servicebus-queue-oauth-connection-events` | Service Bus queue (Azure) | — (oauth-owned) | `azurerm_servicebus_queue.connection_events` in azure/queues.tf; EventGrid subscription on `connection_events_eventgrid_topic_id` |
+| `pubsub-sub-oauth-connection-events` | Pub/Sub subscription (GCP) | — (oauth-owned) | `google_pubsub_subscription.connection_events` in gcp/main.tf; subscribes to `kbc-{stack}-events`; filtered to `storage.devBranchDeleted` |
+
+## Unresolved
+None.
+
+## Notes
+- Legacy migration resources (`LEGACY_OAUTH_DYNAMO_*`, `LEGACY_OAUTH_COSMOSDB_*`, `LEGACY_OAUTH_KMS_ARN`, `LEGACY_OAUTH_KEY_VAULT_URL`) are temporary cross-account/cross-service resources used during migration from the old Node.js oauth-api and Lambda-based service. Marked as TEMPORARY in Terraform comments. Not modelled as named resource instances — they will be removed after migration.
+- The `oauth-service-serverless-proxy` Deployment (nginx) is a routing infrastructure component conditionally deployed to proxy requests to a serverless variant. It has no direct Keboola service dependencies and is not modelled as a C4 component.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service-external.dsl
@@ -1,0 +1,13 @@
+# Cloud resource relationships for omnisearch-service
+# Included at top level of model block in model.dsl
+
+omnisearch-service-api       -> azure-openai-ai-service "LLM and embeddings for lineage analysis using shared Azure OpenAI deployment"
+omnisearch-metastore-builder -> azure-openai-ai-service "LLM and embeddings for lineage analysis using shared Azure OpenAI deployment"
+
+omnisearch-service-api       -> storage-omnisearch-metastore-aws   "reads metastore files on AWS stacks"
+omnisearch-service-api       -> storage-omnisearch-metastore-azure "reads metastore files on Azure stacks"
+omnisearch-service-api       -> storage-omnisearch-metastore-gcp   "reads metastore files on GCP stacks"
+
+omnisearch-metastore-builder -> storage-omnisearch-metastore-aws   "writes metastore files on AWS stacks"
+omnisearch-metastore-builder -> storage-omnisearch-metastore-azure "writes metastore files on Azure stacks"
+omnisearch-metastore-builder -> storage-omnisearch-metastore-gcp   "writes metastore files on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service.dsl
@@ -1,0 +1,6 @@
+# L3 inter-service relationships for omnisearch-service
+# Included inside keboolaPlatform block in model.dsl
+
+omnisearch-service-api       -> connection "verifies storage tokens; reads project and org data via Management API"
+omnisearch-metastore-builder -> connection "collects project objects; creates storage tokens via Management API; uploads lineage metadata"
+omnisearch-metastore-builder -> queue      "reads job history per configuration via QueueClient (URL derived from Storage API URL at runtime)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/omnisearch-service.md
@@ -1,0 +1,23 @@
+# omnisearch-service — dependency analysis
+
+## Deployed components
+- `omnisearch-service-api` (Deployment): FastAPI REST API for lineage and metadata queries
+- `omnisearch-metastore-builder` (CronJob, data-driven per org): Builds and uploads metastore files per organization. Template iterates over `organizationIds` — all instances are one component named `omnisearch-metastore-builder`.
+
+## Inter-service dependencies
+- `omnisearch-service-api` -> `connection`: `kbcstorage.client.Client` using `STORAGE_API_URL` in `restapi/auth.py` — token verification; Management API client (`X-KBC-ManageApiToken`) in `metastore/kbcmanagement.py`
+- `omnisearch-metastore-builder` -> `connection`: `kbcstorage.client.Client` in `metastore/builder.py` and `metastore/metadata_upload.py`; Management API client in `metastore/kbcmanagement.py`
+- `omnisearch-metastore-builder` -> `queue`: `QueueClient` in `metastore/impl.py` — URL derived at runtime via `re.sub(r"((?<=/)|^)connection\.", "queue.", url)`; invisible to ENV scanning
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `azure-openai-ai-service` | Azure OpenAI | ai-service | `azure_open_ai_* = module.azure_openai[0].*` in app_omnisearch_service.tf; present in all three cloud variants |
+| `s3-bucket-logs` | Object storage (logs/metastore) | connection, sync-actions | Metastore files written/read per cloud variant; AWS S3 (`AWS_METASTORE_S3_BUCKET`), Azure ABS, GCP GCS in infra_secrets |
+
+## Unresolved
+None.
+
+## Notes
+- Queue URL is not injected via ENV — derived at runtime in `metastore/impl.py` by substituting `connection.` with `queue.` in the Storage API URL. Invisible to ENV-only scanning.
+- Azure OpenAI is present with non-empty values in all three cloud variants — cross-cloud dependency.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service-external.dsl
@@ -1,0 +1,8 @@
+# Cloud resource relationships for query-service
+# Included at top level of model block in model.dsl
+
+# Shared PostgreSQL — same instance as kai-assistant apps, database: query_service
+query-service-api                    -> postgresql-instance "persists query jobs and results (query_service database)"
+query-service-coordinator            -> postgresql-instance "reads/writes job queue and worker heartbeats"
+query-service-worker                 -> postgresql-instance "reads job queue, writes query results and worker heartbeats"
+query-service-partition-maintenance  -> postgresql-instance "maintains PostgreSQL partitions for job history tables"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service.dsl
@@ -1,0 +1,13 @@
+# L3 inter-service relationships for query-service
+# Included inside keboolaPlatform block in model.dsl
+
+# All components use QUERY_STORAGE_API_HOST = connection.{suffix}
+# for Storage API token verification and workspace credential retrieval.
+query-service-api                    -> connection "verifies tokens and retrieves workspace credentials via Storage API"
+query-service-coordinator            -> connection "verifies tokens and reads stack services map via Storage API"
+query-service-worker                 -> connection "verifies tokens and retrieves workspace credentials via Storage API"
+query-service-partition-maintenance  -> connection "verifies tokens via Storage API"
+
+# Worker executes queries directly against storage backends
+query-service-worker                 -> snowflake  "executes SQL queries against customer Snowflake accounts"
+query-service-worker                 -> bigquery   "executes SQL queries against customer BigQuery projects"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/query-service.md
@@ -1,0 +1,55 @@
+# query-service — dependency analysis
+
+## Deployed components
+
+All components use the same Docker image from `keboola/go-monorepo` (services/query/).
+Each is a separate Deployment/CronJob differentiated by command args.
+
+- `query-service-api` (Deployment): Go REST API. Accepts query requests, manages jobs via
+  PostgreSQL queue. Serves at `query.{suffix}`. Port 8000.
+- `query-service-coordinator` (Deployment): Coordinates query job distribution — monitors
+  worker health via heartbeats, assigns queued jobs to available workers, handles session
+  lifecycle. No external HTTP port.
+- `query-service-worker` (Deployment): Executes SQL queries against Snowflake or BigQuery.
+  Polls job queues from PostgreSQL, opens warehouse sessions, streams results back.
+- `query-service-partition-maintenance` (CronJob, daily at midnight): Manages PostgreSQL
+  table partitions for job history tables. Uses separate `/app/partition-maintenance` binary.
+- `job-migrate` (Job, helm hook pre-install/pre-upgrade): Runs DB migrations. **Skipped**
+  as a C4 component — deploy-time only.
+
+## Inter-service dependencies
+
+- All components -> `connection`: via `QUERY_STORAGE_API_HOST = connection.{suffix}`.
+  Used by `PublicScope` (Storage API services map, stack features) and to verify tokens
+  and retrieve workspace credentials (Snowflake account name, BigQuery project etc.).
+
+## Storage backend dependencies
+
+- `query-service-worker` -> `snowflake`: executes SQL queries directly against customer
+  Snowflake accounts using workspace credentials retrieved from Connection.
+- `query-service-worker` -> `bigquery`: executes SQL queries directly against customer
+  BigQuery projects using service account credentials retrieved from Connection.
+
+## Named cloud resource dependencies
+
+| Resource ID | Type | Evidence |
+|---|---|---|
+| `rds-postgresql` | Shared PostgreSQL RDS | `QUERY_DB_*` injected from `kubernetes-postgresql-init` module; same shared RDS instance as kai-assistant apps. Database name: `query_service`. |
+
+## Encryption
+
+`QUERY_ENCRYPTION_AES_SECRET_KEY` (32-byte AES-256 key, base64) is injected via
+`query-service-env-secrets` Kubernetes Secret. Used by `internal/encryption` package
+(go-cloud-encrypt) to encrypt workspace credentials at rest in PostgreSQL.
+
+This is **application-managed AES encryption** — NOT cloud KMS. No AWS KMS, Azure Key Vault,
+or GCP Cloud KMS is involved. Do NOT add a cloud KMS resource relationship.
+
+## Notes
+
+- The coordinator and worker communicate exclusively via PostgreSQL queues (LISTEN/NOTIFY +
+  partitioned job tables). No direct HTTP calls between components.
+- `query-service-partition-maintenance` CronJob uses a separate binary
+  (`/app/partition-maintenance`) but the same Docker image as the other components.
+- The Terraform module has only a single cloud variant (no aws/azure/gcp subdirectory split)
+  — it uses the shared PostgreSQL RDS which already exists on all clouds.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api-external.dsl
@@ -1,0 +1,10 @@
+# Cloud resource relationships for runner-sync-api
+# Included at top level of model block in model.dsl
+
+sync-actions-api -> kms-key-job-runner-aws   "decrypts component configuration in spawned sync-action pods on AWS stacks"
+sync-actions-api -> kms-key-job-runner-azure "decrypts component configuration in spawned sync-action pods on Azure stacks"
+sync-actions-api -> kms-key-job-runner-gcp   "decrypts component configuration in spawned sync-action pods on GCP stacks"
+sync-actions-api -> s3-bucket-logs           "writes job artefacts and logs"
+sync-actions-api -> aws-eks                  "spawns sync action pods via Kubernetes API"
+sync-actions-api -> azure-aks                "spawns sync action pods via Kubernetes API"
+sync-actions-api -> gcp-gke                  "spawns sync action pods via Kubernetes API"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for runner-sync-api
+# Included inside keboolaPlatform block in model.dsl
+
+sync-actions-api -> connection "reads component configs and verifies tokens via Storage API"
+sync-actions-api -> vault      "resolves variables before job execution"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/runner-sync-api.md
@@ -1,0 +1,20 @@
+# runner-sync-api — dependency analysis
+
+## Deployed components
+- `sync-actions-api` (Deployment): container `runner-sync-api` (PHP API)
+
+## Inter-service dependencies
+- `sync-actions-api` -> `connection`: `STORAGE_API_URL` via `Keboola\StorageApiBranch\Factory\ClientOptions` and `Keboola\ManageApi\Client` in services.yaml
+- `sync-actions-api` -> `vault`: `VAULT_API_URL` via `App\VaultVariablesApiClientFactory` in services.yaml
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `kms-key-job-runner-aws` | KMS key (AWS) | encryption-api, job-queue-daemon, queue-runner | `job_runner_kms_key_id = data.aws_cloudformation_stack.kbc_job_runner_kms_key...` in app_runner_sync_api.tf; `s3:PutObject` IAM policy on `runner_sync_api_debug_logs` confirms S3 usage too |
+| `kms-key-job-runner-azure` | Key Vault key (Azure) | encryption-api, job-queue-daemon, queue-runner | `AZURE_KEY_VAULT_URL` in azure/main.tf |
+| `kms-key-job-runner-gcp` | Cloud KMS key (GCP) | encryption-api, job-queue-daemon, queue-runner | `GCP_KMS_KEY_ID` in gcp/main.tf |
+| `s3-bucket-logs` | Object storage | connection, omnisearch | `logs_bucket_arn` in app_runner_sync_api.tf; IAM policy `runner_sync_api_debug_logs` confirms `s3:PutObject` |
+
+## Unresolved
+- `GELF_SERVER_URL`: used in `KubernetesSpecificationProvider` — injected into spawned pods as logging endpoint, not a direct HTTP dependency of sync-actions-api itself
+- `K8S_HOST`, `K8S_TOKEN`, `K8S_CA_CERT_PATH`, `K8S_NAMESPACE`: Kubernetes API credentials — service spawns sync action pods directly via `Keboola\K8sClient\KubernetesApiClientFacade`

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service-external.dsl
@@ -1,0 +1,75 @@
+# Cloud resource relationships for sandboxes
+# Included at top level of model block in model.dsl
+
+# --- sandboxes-service-api ---
+sandboxes-service-api -> mysql-instance-job-queue              "persists sandbox and app records (data_science database)"
+sandboxes-service-api -> kms-key-job-runner-aws                "decrypts app OAuth/config secrets encrypted by job-queue component on AWS stacks"
+sandboxes-service-api -> kms-key-job-runner-azure              "decrypts app OAuth/config secrets encrypted by job-queue component on Azure stacks"
+sandboxes-service-api -> kms-key-job-runner-gcp                "decrypts app OAuth/config secrets encrypted by job-queue component on GCP stacks"
+sandboxes-service-api -> kms-key-sandboxes-service-aws         "internal encryption of app configuration on AWS stacks"
+sandboxes-service-api -> kms-key-sandboxes-service-azure       "internal encryption of app configuration on Azure stacks"
+sandboxes-service-api -> kms-key-sandboxes-service-gcp         "internal encryption of app configuration on GCP stacks"
+sandboxes-service-api -> aws-eks                               "spawns and manages sandbox/app pods via Kubernetes API"
+sandboxes-service-api -> azure-aks                             "spawns and manages sandbox/app pods via Kubernetes API"
+sandboxes-service-api -> gcp-gke                               "spawns and manages sandbox/app pods via Kubernetes API"
+
+# --- sandboxes-service-garbage-collector ---
+sandboxes-service-garbage-collector -> mysql-instance-job-queue "reads sandbox records to identify orphans"
+sandboxes-service-garbage-collector -> aws-eks                  "deletes orphaned pods and PVCs via Kubernetes API"
+sandboxes-service-garbage-collector -> azure-aks                "deletes orphaned pods and PVCs via Kubernetes API"
+sandboxes-service-garbage-collector -> gcp-gke                  "deletes orphaned pods and PVCs via Kubernetes API"
+
+# --- sandboxes-service-suspend ---
+sandboxes-service-suspend -> mysql-instance-job-queue "reads app records to find inactive sandboxes and apps"
+sandboxes-service-suspend -> aws-eks                  "lists running App CRDs and transitions expired apps via Kubernetes API"
+sandboxes-service-suspend -> azure-aks                "lists running App CRDs and transitions expired apps via Kubernetes API"
+sandboxes-service-suspend -> gcp-gke                  "lists running App CRDs and transitions expired apps via Kubernetes API"
+
+# --- apps-proxy ---
+# Watches App CRDs via K8s dynamic client (AppStateWatcher) to determine pod routing.
+# Also calls sandboxes-service-api for app config and auth (in internal DSL).
+apps-proxy -> aws-eks   "watches App CRDs to determine running state and route traffic to app pods"
+apps-proxy -> azure-aks "watches App CRDs to determine running state and route traffic to app pods"
+apps-proxy -> gcp-gke   "watches App CRDs to determine running state and route traffic to app pods"
+
+# --- sandboxes-service-purge-app-runs ---
+sandboxes-service-purge-app-runs -> mysql-instance-job-queue "deletes AppRun records completed more than 6 months ago"
+
+# --- sandboxes-service-prune-app-run-logs ---
+sandboxes-service-prune-app-run-logs -> mysql-instance-job-queue "prunes startup log data from AppRun records completed more than 7 days ago"
+
+# --- sandboxes component (ephemeral job pod) ---
+# Directly manages K8s resources (pods, services) using keboola/k8s-client
+sandboxes-component -> aws-eks   "directly creates and manages sandbox/app pods via Kubernetes API"
+sandboxes-component -> azure-aks "directly creates and manages sandbox/app pods via Kubernetes API"
+sandboxes-component -> gcp-gke   "directly creates and manages sandbox/app pods via Kubernetes API"
+
+# --- Pattern B: consumers read from subscriber-owned queues ---
+sandboxes-service-messenger-consumer-connection-events    -> sqs-queue-sandboxes-service-connection-events        "consumes connection events on AWS stacks"
+sandboxes-service-messenger-consumer-connection-events    -> servicebus-queue-sandboxes-service-connection-events "consumes connection events on Azure stacks"
+sandboxes-service-messenger-consumer-connection-events    -> pubsub-sub-sandboxes-service-connection-events       "consumes connection events on GCP stacks"
+
+sandboxes-service-messenger-consumer-connection-audit-log -> sqs-queue-sandboxes-service-connection-audit-log        "consumes connection audit log events on AWS stacks"
+sandboxes-service-messenger-consumer-connection-audit-log -> servicebus-queue-sandboxes-service-connection-audit-log "consumes connection audit log events on Azure stacks"
+sandboxes-service-messenger-consumer-connection-audit-log -> pubsub-sub-sandboxes-service-connection-audit-log       "consumes connection audit log events on GCP stacks"
+
+# --- Pattern B: subscriber queues receive from Connection topics ---
+sqs-queue-sandboxes-service-connection-events        -> sns-topic-connection-events        "subscribed via aws_sns_topic_subscription"
+servicebus-queue-sandboxes-service-connection-events -> eventgrid-topic-connection-events  "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-sandboxes-service-connection-events       -> pubsub-topic-connection-events     "subscribed via google_pubsub_subscription"
+
+sqs-queue-sandboxes-service-connection-audit-log        -> sns-topic-connection-audit-log        "subscribed via aws_sns_topic_subscription"
+servicebus-queue-sandboxes-service-connection-audit-log -> eventgrid-topic-connection-audit-log  "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-sandboxes-service-connection-audit-log       -> pubsub-topic-connection-audit-log     "subscribed via google_pubsub_subscription"
+
+# --- keboola-operator ---
+# Runs INSIDE the cluster using in-cluster credentials (InClusterClientFacadeFactory).
+# This is still an explicit application-level K8s API interaction -- the operator manages
+# App, StorageToken, and E2bSandbox custom resources via controller-runtime.
+# This is NOT the generic "runs-on" relationship -- it is the operator's raison d'être.
+keboola-operator -> aws-eks    "manages App, StorageToken, E2bSandbox CRDs via controller-runtime (in-cluster)"
+keboola-operator -> azure-aks  "manages App, StorageToken, E2bSandbox CRDs via controller-runtime (in-cluster)"
+keboola-operator -> gcp-gke    "manages App, StorageToken, E2bSandbox CRDs via controller-runtime (in-cluster)"
+keboola-operator -> kms-key-job-runner-aws    "decrypts app configuration secrets using job-runner KMS key on AWS stacks"
+keboola-operator -> kms-key-job-runner-azure  "decrypts app configuration secrets using job-runner Key Vault key on Azure stacks"
+keboola-operator -> kms-key-job-runner-gcp    "decrypts app configuration secrets using job-runner GCP KMS key on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service.dsl
@@ -1,0 +1,32 @@
+# L3 inter-service relationships for sandboxes
+# Included inside keboolaPlatform block in model.dsl
+
+# sandboxes-service-api
+sandboxes-service-api -> connection   "verifies tokens, reads project context, manages workspaces via Storage and Manage APIs"
+sandboxes-service-api -> billing      "reports sandbox and app usage (BILLING_ENABLED)"
+sandboxes-service-api -> encryption   "decrypts app proxy auth configuration via Encryption API"
+sandboxes-service-api -> git-service  "manages Git repositories for apps (internal cluster URL)"
+
+# garbage collector
+sandboxes-service-garbage-collector -> connection "reads project/token context via Storage API"
+
+# suspend -- reads app records, provisions tokens via StorageApiTokenProvider, manages K8s state
+sandboxes-service-suspend -> connection "retrieves provisioning tokens via StorageApiTokenProvider for app state transitions"
+
+# messenger consumers — Pattern B: receive events from Connection
+sandboxes-service-messenger-consumer-connection-events    -> connection "receives project and sandbox lifecycle events published by Connection (async)"
+sandboxes-service-messenger-consumer-connection-audit-log -> connection "receives audit log events published by Connection (async)"
+
+# apps-proxy -- calls sandboxes-service-api for app config and auth; ALSO directly watches App CRDs
+# in K8s via AppStateWatcher (dynamic client) to determine running state and route traffic to pods.
+# Note: relationship to sandboxes-service-api only (not the container) -- Structurizr prohibits parent-child relationships
+apps-proxy -> sandboxes-service-api "fetches app configuration and validates requests via Sandboxes Service API"
+
+# keboola-operator -- runs INSIDE the cluster (in-cluster credentials), not an external caller.
+# K8s API usage is internal to its operation as a controller. External dependencies only:
+keboola-operator -> connection "provisions Storage tokens and reads project context via APPLICATION_TOKEN"
+keboola-operator -> e2b        "manages E2B sandbox lifecycle for E2bSandbox CRDs via E2B_API_KEY"
+
+# sandboxes component (ephemeral job pod — runs via job-queue runner infrastructure)
+sandboxes-component -> connection         "reads Storage API data and performs input/output mapping"
+sandboxes-component -> sandboxes-service-api "manages sandbox and app lifecycle via Sandboxes Service API client"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sandboxes-service.md
@@ -1,0 +1,144 @@
+# sandboxes — dependency analysis
+
+## Deployed components
+
+### sandboxes-service (PHP/Symfony, repo: keboola/sandboxes-service)
+
+- `sandboxes-service-api` (Deployment): PHP/Symfony REST API served by RoadRunner.
+  Central API for Workspaces (Python/R sandboxes) and Apps (Data Apps). Serves at
+  `data-science.{suffix}`. Manages sandbox lifecycle, app provisioning strategies,
+  and app proxy configuration.
+
+- `sandboxes-service-garbage-collector` (CronJob, every 15min): Cleans up orphaned
+  K8s resources (pods, PVCs, persistent storages). Reads DB, calls K8s API directly.
+
+- `sandboxes-service-messenger-consumer-connection-events` (Deployment): Symfony
+  Messenger consumer. Receives Connection events (Pattern B fan-out from Connection
+  events topic). Handles project/workspace lifecycle events.
+
+- `sandboxes-service-messenger-consumer-connection-audit-log` (Deployment): Symfony
+  Messenger consumer. Receives Connection audit log events (Pattern B fan-out).
+
+- `sandboxes-service-sync-app-runs-watch` (Deployment): Watches K8s AppRun CRDs and
+  syncs their state back to sandboxes-service database.
+
+- `sandboxes-service-suspend` (CronJob): Suspends idle apps and sandboxes.
+  Reads app records from MySQL, lists running App CRDs from K8s, transitions expired
+  apps to stopped state. Uses `StorageApiTokenProvider` to retrieve provisioning tokens
+  from Connection. Dependencies: MySQL + K8s API + Connection.
+
+- `sandboxes-service-purge-app-runs` (CronJob): Deletes AppRun records completed
+  more than 6 months ago. MySQL only (`AppRunRepository::purgeAppRunsCompletedBefore`).
+
+- `sandboxes-service-prune-app-run-logs` (CronJob): Nulls startup log fields on AppRun
+  records completed more than 7 days ago. MySQL only
+  (`AppRunRepository::pruneLogsFromAppRunsCompletedBefore`).
+
+- `sandboxes-service-db-migration` (Job, helm hook): DB migrations. Skipped — deploy-time only.
+
+### apps-proxy (Go, repo: keboola/keboola-as-code, cmd/apps-proxy)
+
+- `apps-proxy` (Deployment): Go reverse proxy for Data Apps. Routes incoming HTTP
+  requests to the correct app pod via K8s. Authenticates users via sandboxes-service.
+  Only used for Apps, not Sandboxes. Has an E2B webhook forwarding endpoint.
+
+### keboola-operator (Go, repo: keboola/keboola-operator)
+
+- `keboola-operator-controller-manager` (Deployment): Kubernetes operator managing
+  custom resources: `App`, `StorageToken`, `E2bSandbox` CRDs. Provisions and
+  lifecycle-manages App pods in the K8s cluster. Handles E2B sandbox CRDs.
+  Decrypts app configuration using ObjectEncryptor (job-runner KMS key).
+
+### sandboxes component (PHP, repo: keboola/sandboxes)
+
+Runs as ephemeral job pods via the job-queue infrastructure (not a persistent service).
+This is a Keboola component (keboola.sandboxes) that abuses the job-queue runner
+mechanism to perform asynchronous K8s operations. Receives jobs from UI via
+connection → queue → job-runner path. Manages sandbox/app K8s resources directly.
+Being phased out for Apps (replaced by operator), remains standard path for Workspaces.
+
+## Inter-service dependencies
+
+### sandboxes-service-api
+- `connection`: via `getConnectionServiceUrl()` — Storage API (token verify, workspace
+  credentials, project context) + Manage API (`Keboola\ManageApi\Client`)
+- `billing`: via `getBillingServiceUrl()` — `Keboola\BillingApi\ClientFactory`
+  (`BILLING_ENABLED` flag; still model)
+- `encryption`: via `getEncryptionServiceUrl()` — `EncryptionClientFactory` for
+  app proxy auth config decryption
+- `git-service`: hardcoded cluster URL
+  `http://git-service.git-service.svc.cluster.local` for git repository management
+
+### sandboxes-service-garbage-collector
+- `connection`: via ServiceClient (same URL as api)
+- K8s API: deletes orphaned pods and PVCs
+
+### sandboxes-service-suspend
+- `connection`: via `StorageApiTokenProvider` — retrieves provisioning tokens for
+  transitioning app state (e.g. stopping an expired app via operator strategy)
+- K8s API: lists running App CRDs, transitions their desired state
+
+### sandboxes-service-messenger-consumer-connection-events
+- `connection`: receives Connection events (Pattern B async)
+
+### sandboxes-service-messenger-consumer-connection-audit-log
+- `connection`: receives Connection audit log events (Pattern B async)
+
+### sandboxes-service-purge-app-runs
+- MySQL only: deletes old AppRun records. No inter-service calls.
+
+### sandboxes-service-prune-app-run-logs
+- MySQL only: prunes log data from AppRun records. No inter-service calls.
+
+### sandboxes-service-sync-app-runs-watch
+- K8s API only (watches AppRun CRDs) — no inter-Keboola-service calls
+
+### apps-proxy
+- `sandboxes-service-api`: via `APPS_PROXY_SANDBOXES_API_URL` + `APPS_PROXY_SANDBOXES_API_TOKEN`
+  (app config, auth, routing decisions). Note: relationship is to the component, not the
+  container — Structurizr prohibits parent-child relationships.
+
+### keboola-operator
+- `connection`: via `APPLICATION_TOKEN` — Storage API token used to authenticate
+  operator actions (workspace/token provisioning)
+- `e2b`: via `E2B_API_KEY` — manages E2B sandboxes for E2bSandbox CRDs
+
+### sandboxes component (ephemeral job pod)
+- `connection`: via `keboola/storage-api-client` (Storage API, input/output mapping)
+- `sandboxes-service-api`: via `keboola/sandboxes-service-api-client`
+
+## Named cloud resource dependencies
+
+| Resource | Type | Evidence |
+|---|---|---|
+| `mysql-instance-job-queue` | MySQL | `mysql_config = local.job_queue_mysql_config` in stack-level tf. Used by api, gc, suspend, purge, prune. |
+| `kms-key-job-runner-aws/azure/gcp` | Shared KMS | `AWS_KMS_KEY_ID_JOB_QUEUE` / `AZURE_KEY_VAULT_URL_JOB_QUEUE` / `GCP_KMS_KEY_ID_JOB_QUEUE`. Used by `app.object_encryptor.job_queue` to **decrypt** app OAuth/config secrets that were **encrypted by the job-queue component** using this shared key. Also used by keboola-operator for the same purpose. |
+| `kms-key-sandboxes-service-aws/azure/gcp` | Service-owned KMS | `AWS_KMS_KEY_ID_INTERNAL` (`aws_kms_key.sandboxes_service`). Used by `app.object_encryptor.internal` for sandboxes-service's own internal encryption (e.g. operator provisioning strategy). |
+| `sqs-queue-sandboxes-service-connection-events` | SQS (Pattern B) | `aws_sqs_queue.connection_events` + `aws_sns_topic_subscription` → `connection_events_topic_arn` |
+| `sqs-queue-sandboxes-service-connection-audit-log` | SQS (Pattern B) | `aws_sqs_queue.connection_audit_log` + `aws_sns_topic_subscription` → `connection_audit_log_topic_arn` |
+| `aws-eks` / `azure-aks` / `gcp-gke` | K8s cluster | `Keboola\K8sClient` + `KubernetesApiFacade` — used by api, gc, and suspend |
+
+## Provisioning paths summary
+
+| Product | Standard path | Secondary / phasing in | Uncommissioned |
+|---|---|---|---|
+| Workspaces (Python/R) | sandboxes component via job-queue | operator (phasing in) | — |
+| Apps | operator | sandboxes component (phasing out) | E2B |
+
+## Notes
+
+- `sandboxes-api` repo (`keboola/sandboxes-api`) is removed — do not reference it.
+- SQL Workspaces are exclusively managed by `editor-service`, not sandboxes.
+- `apps-proxy` is in `keboola-as-code` monorepo under `cmd/apps-proxy`. It is a
+  component of the `sandboxes` C4 container.
+- `keboola-operator` has no Terraform module at
+  `infrastructure/terraform/modules/app-keboola-operator/`. Config injected entirely
+  via kbc-stacks `secret-config.yaml`.
+- EFS/ABS/GCS persistent storage resources for Workspaces are cluster infrastructure,
+  not service-owned app resources — not modelled as named C4 resources.
+- **Why job-runner KMS key in sandboxes-service?** App configurations can contain OAuth
+  credentials or other secrets. When those configs are created via the job-queue
+  component (keboola.sandboxes), they get encrypted with the shared job-runner KMS key.
+  When sandboxes-service later needs to inject those secrets into app pods (e.g. for
+  app proxy auth), it must decrypt them — requiring the same key. This is a
+  cross-service decrypt dependency, not sandboxes-service doing its own encryption.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer-external.dsl
@@ -1,0 +1,4 @@
+# Cloud resource relationships for sapi-importer
+# Included at top level of model block in model.dsl
+# sapi-importer has no cloud resource dependencies of its own.
+# (No Terraform module, no KMS, no database, no queues, no object storage.)

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer.dsl
@@ -1,0 +1,4 @@
+# L3 inter-service relationships for sapi-importer
+# Included inside keboolaPlatform block in model.dsl
+
+sapi-importer-api -> connection "imports files into Storage via Storage API"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/sapi-importer.md
@@ -1,0 +1,20 @@
+# sapi-importer — dependency analysis
+
+## Deployed components
+- `sapi-importer-api` (Deployment): PHP REST API. Accepts file upload requests and imports them into Storage via the Storage API.
+
+## Inter-service dependencies
+- `sapi-importer-api` -> `connection`: `STORAGE_API_URL` via `App\StorageApi\ClientFactory` in services.yaml — all import operations go through the Storage API
+
+## Named cloud resource dependencies
+None. sapi-importer has no Terraform module and no infra_secrets. It has no database,
+no KMS key, no queues, and no object storage of its own. All state is managed via
+the Storage API (Connection).
+
+## Unresolved
+None.
+
+## Notes
+- `STORAGE_API_URL` is injected via ConfigMap (not infra_secrets) — derived from
+  `hostnameSuffix` in values.yaml as `https://connection.{hostnameSuffix}`. This is
+  invisible to Terraform-based scanning; must be found in the kbc-stacks ConfigMap template.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler-external.dsl
@@ -1,0 +1,12 @@
+# Cloud resource relationships for scheduler
+# Included at top level of model block in model.dsl
+
+scheduler-api  -> mysql-instance-job-queue "persists schedules (shares job-queue MySQL instance)"
+scheduler-api  -> kms-key-scheduler-aws   "encrypts data at rest on AWS stacks"
+scheduler-api  -> kms-key-scheduler-azure "encrypts data at rest on Azure stacks"
+scheduler-api  -> kms-key-scheduler-gcp   "encrypts data at rest on GCP stacks"
+
+scheduler-cron -> mysql-instance-job-queue "reads due schedules (shares job-queue MySQL instance)"
+scheduler-cron -> kms-key-scheduler-aws   "encrypts data at rest on AWS stacks"
+scheduler-cron -> kms-key-scheduler-azure "encrypts data at rest on Azure stacks"
+scheduler-cron -> kms-key-scheduler-gcp   "encrypts data at rest on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler.dsl
@@ -1,0 +1,6 @@
+# L3 inter-service relationships for scheduler
+# Included inside keboolaPlatform block in model.dsl
+
+scheduler-api  -> connection "verifies tokens and reads/writes schedule configurations via Storage API"
+scheduler-cron -> connection "verifies tokens via Storage API"
+scheduler-cron -> queue      "triggers scheduled jobs"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/scheduler.md
@@ -1,0 +1,18 @@
+# scheduler — dependency analysis
+
+## Deployed components
+- `scheduler-api` (Deployment): container `scheduler-api` (PHP REST API)
+- `scheduler-cron` (CronJob, every minute): command `php bin/console app:run`
+
+## Inter-service dependencies
+- `scheduler-api` -> `connection`: `storage_api_url` via `Keboola\StorageApiBranch` in services.yaml
+- `scheduler-cron` -> `connection`: `storage_api_url` via `Keboola\StorageApiBranch` in services.yaml
+- `scheduler-cron` -> `queue`: `queue_api_url` via `Keboola\App\JobQueueClientFactory` in services.yaml
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, vault, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_scheduler.tf |
+
+## Unresolved
+None.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/stream-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/stream-external.dsl
@@ -1,0 +1,13 @@
+# Cloud resource relationships for stream
+# Included at top level of model block in model.dsl
+
+# Service-owned KMS / Key Vault keys — used for encrypting data payloads written to disk volumes
+stream-storage-writer -> kms-key-stream-aws   "encrypts data payloads written to disk on AWS stacks"
+stream-storage-writer -> kms-key-stream-azure "encrypts data payloads written to disk on Azure stacks"
+stream-storage-writer -> kms-key-stream-gcp   "encrypts data payloads written to disk on GCP stacks"
+
+# etcd snapshot storage — used by Bitnami disaster recovery cronjob (not runtime application dependency)
+# Note: these are storage backends for etcd's own backup/restore, not used by stream application code directly
+stream-etcd -> efs-stream-etcd-snapshots  "stores etcd snapshots for disaster recovery on AWS stacks"
+stream-etcd -> abs-stream-etcd-snapshots  "stores etcd snapshots for disaster recovery on Azure stacks"
+stream-etcd -> gcs-stream-etcd-snapshots  "stores etcd snapshots for disaster recovery on GCP stacks"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/stream.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/stream.dsl
@@ -1,0 +1,14 @@
+# L3 inter-service relationships for stream
+# Included inside keboolaPlatform block in model.dsl
+
+stream-api                    -> connection "validates tokens and reads stream/sink configurations via Storage API"
+stream-storage-coordinator    -> connection "imports staged files into Keboola Storage tables"
+stream-storage-writer         -> connection "uploads encoded data slices to Storage staging files"
+stream-storage-reader         -> connection "reads staged slices for upload to Storage"
+
+# Internal cluster coordination
+stream-api                    -> stream-etcd "uses for distributed node coordination, task locking, and state machine"
+stream-http-source            -> stream-etcd "uses for distributed node registration and slice routing"
+stream-storage-coordinator    -> stream-etcd "uses for file/slice lifecycle state machine"
+stream-storage-writer         -> stream-etcd "uses for slice state and statistics sync"
+stream-storage-reader         -> stream-etcd "uses for slice state and statistics sync"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/stream.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/stream.md
@@ -1,0 +1,58 @@
+# stream — dependency analysis
+
+## Deployed components
+- `stream-api` (Deployment): Go REST API. Manages stream definitions (sources, sinks). Authenticates
+  via Storage API. All components run the same binary with different `--args`.
+- `stream-http-source` (Deployment): HTTP ingest endpoint. Accepts incoming data records from external
+  producers. High-replica, CPU-bound.
+- `stream-storage-coordinator` (Deployment): Orchestrates the lifecycle of slices and files — triggers
+  uploads and imports into Keboola Storage.
+- `stream-storage-writer` (StatefulSet container): Receives encoded data from http-source nodes over
+  TCP/KCP network transport, buffers to local disk volumes.
+- `stream-storage-reader` (StatefulSet container): Reads locally buffered data and uploads to staging
+  storage, then triggers import into Keboola Storage (connection). Co-located with writer in one
+  StatefulSet pod (`stream-storage-writer-reader`).
+
+## Inter-service dependencies
+- All components -> `connection`: via `storageApiHost: "connection.{{ .Values.hostnameSuffix }}"` in
+  config.yaml. Used for token validation (API), and for staging file upload + table import
+  (storage-coordinator, storage-writer, storage-reader).
+
+## Named cloud resource dependencies
+| Resource ID | Type | Evidence |
+|---|---|---|
+| `kms-key-stream-aws` | AWS KMS key (service-owned) | `aws_kms_key.stream_encryption` in aws/main.tf. ENV: `STREAM_ENCRYPTION_AWS_KMS_KEY_ID` |
+| `kms-key-stream-azure` | Azure Key Vault key (service-owned) | `azurerm_key_vault_key.stream_encryption` in azure/main.tf. ENV: `STREAM_ENCRYPTION_AZURE_KEY_NAME`, `STREAM_ENCRYPTION_AZURE_KEY_VAULT_URL` |
+| `kms-key-stream-gcp` | GCP Cloud KMS key (service-owned) | `google_kms_crypto_key.stream_encryption` in gcp/main.tf |
+| `efs-stream-etcd-snapshots` | AWS EFS file system | `aws_efs_file_system.stream_etcd_snapshots` in aws/snapshots.tf. Used as StorageClass for etcd snapshots |
+| `abs-stream-etcd-snapshots` | Azure Blob Storage account | `azurerm_storage_account.stream_etcd_snapshots` in azure/snapshots.tf. Used as StorageClass for etcd snapshots |
+| `gcs-stream-etcd-snapshots` | GCP GCS bucket | `google_storage_bucket.stream_etcd_snapshots_bucket` in gcp/main.tf. Used for etcd disaster recovery snapshots |
+
+## etcd — separate instance from templates-api (IMPORTANT)
+
+Stream deploys its own Bitnami etcd sub-chart (`stream-etcd`, `fullnameOverride: stream-etcd`)
+as part of the stream Helm release, in the `stream` K8s namespace.
+
+**This is completely separate from `templates-api-etcd`** (which is in the `templates-api` namespace).
+
+| | stream etcd | templates-api etcd |
+|---|---|---|
+| Endpoint | `stream-etcd.stream.svc.cluster.local:2379` | `templates-api-etcd.templates-api.svc.cluster.local:2379` |
+| Namespace (etcd data) | `stream/` | `templates-api` |
+| K8s namespace | `stream` | `templates-api` |
+| Replicas | 1 (default, configurable) | 3 |
+| Purpose | Distributed cluster coordination (node registration, slice/file state machine, statistics sync, task locking) | Write atomicity locking only |
+| Snapshot storage | EFS (AWS) / ABS (Azure) / GCS (GCP) — via Kubernetes StorageClass + Bitnami disaster recovery | None (no snapshot config) |
+
+## New resources added to cloud-resources.dsl
+- `kms-key-stream-aws`, `kms-key-stream-azure`, `kms-key-stream-gcp`: stream-owned encryption keys
+- `efs-stream-etcd-snapshots`: AWS EFS for etcd snapshot storage
+- `abs-stream-etcd-snapshots`: Azure Blob Storage for etcd snapshot storage
+- `gcs-stream-etcd-snapshots`: GCP GCS bucket for etcd snapshot storage
+
+## Notes
+- All stream components use the same Docker image, differentiated only by the `args` field
+  (`api`, `http-source`, `storage-coordinator`, `storage-writer`, `storage-reader`).
+- The KMS keys encrypt the data payloads written to disk volumes by the writer — not db encryption.
+- The etcd snapshot storage (EFS/ABS/GCS) is used by the Bitnami etcd `disasterRecovery` cronjob.
+  It is NOT a runtime application dependency — it is a backup/restore mechanism for etcd itself.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api-external.dsl
@@ -1,0 +1,7 @@
+# Cloud resource relationships for templates-api
+# Included at top level of model block in model.dsl
+# templates-api has no cloud resource dependencies of its own.
+# (No Terraform module, no KMS, no database, no queues, no object storage.)
+# etcd is self-hosted as a Helm sub-chart co-deployed with templates-api.
+
+templates-api -> github "clones template repositories at runtime to read template definitions (keboola/keboola-as-code-templates)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for templates-api
+# Included inside keboolaPlatform block in model.dsl
+
+templates-api -> connection          "verifies tokens, reads and writes project configurations via Storage API"
+templates-api -> templates-api-etcd  "uses for distributed locking to ensure write atomicity"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/templates-api.md
@@ -1,0 +1,35 @@
+# templates-api — dependency analysis
+
+## Deployed components
+- `templates-api` (Deployment): Go REST API. Applies configuration templates to Keboola projects.
+  Built from `cmd/templates-api/main.go` in `keboola-as-code` monorepo.
+- `templates-api-etcd` (Bitnami etcd sub-chart, 3 replicas): Self-hosted etcd cluster deployed
+  as a Helm sub-chart within the templates-api release. Used for distributed locking to ensure
+  atomicity of write operations. Runs in the `templates-api` namespace.
+
+## Inter-service dependencies
+- `templates-api` -> `connection`: `TEMPLATES_STORAGE_API_HOST` =
+  `https://connection.{hostnameSuffix}` from ConfigMap (via `_helpers.tpl`). Used to verify
+  tokens, read project configurations, and write template-applied configurations back to Storage.
+
+## External dependencies (outside keboolaPlatform)
+- `templates-api` -> GitHub (`github.com/keboola/keboola-as-code-templates.git`): The API
+  clones Git repositories at runtime to read template definitions.
+  Default repos: `keboola` (main), `keboola-beta` (beta), `keboola-dev` (dev),
+  plus `ComponentsTemplateRepositoryURL` (main+beta branches).
+  Source: `DefaultTemplateRepositoryURL` in `internal/pkg/template/repository/default.go`.
+
+## Named cloud resource dependencies
+None. No Terraform module for templates-api.
+
+## Unresolved
+None.
+
+## Notes
+- `TEMPLATES_STORAGE_API_HOST` is injected via ConfigMap (not infra_secrets) — derived from
+  `hostnameSuffix` in values.yaml. Invisible to Terraform-based scanning.
+- etcd is bundled as a Helm sub-chart (Bitnami), not a separate kbc-stacks app. It is
+  self-hosted infrastructure co-deployed with the templates-api, not a managed cloud service.
+  etcd availability is not critical — the API degrades gracefully without it (loses atomicity).
+- GitHub access at runtime is a notable architectural dependency not visible from Terraform or
+  kbc-stacks — the API actively clones public GitHub repos to read template definitions.

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/vault-external.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/vault-external.dsl
@@ -1,0 +1,16 @@
+# Cloud resource relationships for vault
+# Included at top level of model block in model.dsl
+
+vault-api                                  -> mysql-instance-job-queue "persists variables (shares job-queue MySQL instance)"
+
+# Messenger consumer reads from vault-owned queue subscriptions on each cloud.
+# Each queue is fanned out from Connection's per-cloud events topic.
+vault-messenger-consumer-connection-events -> mysql-instance-job-queue                    "deletes branch variables on devBranchDeleted events"
+vault-messenger-consumer-connection-events -> sqs-queue-vault-connection-events           "consumes devBranchDeleted events on AWS stacks (subscribed to sns-topic-connection-events)"
+vault-messenger-consumer-connection-events -> servicebus-queue-vault-connection-events    "consumes devBranchDeleted events on Azure stacks (fanned from eventgrid-topic-connection-events)"
+vault-messenger-consumer-connection-events -> pubsub-sub-vault-connection-events          "consumes devBranchDeleted events on GCP stacks (subscribed to pubsub-topic-connection-events)"
+
+# The vault-owned queues receive from Connection's events topics
+sqs-queue-vault-connection-events          -> sns-topic-connection-events                 "subscribed via aws_sns_topic_subscription"
+servicebus-queue-vault-connection-events   -> eventgrid-topic-connection-events           "subscribed via azurerm_eventgrid_event_subscription"
+pubsub-sub-vault-connection-events         -> pubsub-topic-connection-events              "subscribed via google_pubsub_subscription"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/vault.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/vault.dsl
@@ -1,0 +1,5 @@
+# L3 inter-service relationships for vault
+# Included inside keboolaPlatform block in model.dsl
+
+vault-api                                  -> connection "verifies tokens and records Storage audit events via Storage API"
+vault-messenger-consumer-connection-events -> connection "receives devBranchDeleted events published by Connection (async, via cloud queue)"

--- a/plugins/developer/skills/keboola-architecture/references/c4/l3/vault.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/l3/vault.md
@@ -1,0 +1,25 @@
+# vault — dependency analysis
+
+## Deployed components
+- `vault-api` (Deployment): PHP REST API — CRUD for variables and credentials
+- `vault-messenger-consumer-connection-events` (Deployment): command `messenger:consume connection_events` — listens for `devBranchDeleted` events and purges associated branch variables from the local DB
+
+## Inter-service dependencies
+- `vault-api` -> `connection`: `Keboola\StorageApiBranch\Factory\ClientOptions` with `STORAGE_API_URL` in services.yaml; `Keboola\StorageApi\Tokens` in `StorageEventRecorder.php` — token validation and audit event recording
+- `vault-messenger-consumer-connection-events` -> `connection`: receives `devBranchDeleted` events published by Connection (async, via cloud queue transport)
+
+## Named cloud resource dependencies
+| Resource ID | Type | Shared with | Evidence |
+|---|---|---|---|
+| `mysql-instance-job-queue` | MySQL instance | job-queue, editor, scheduler, notification, ai, billing | `mysql_config = local.job_queue_mysql_config` in app_vault.tf |
+| `sqs-queue-vault-connection-events` | SQS queue (AWS) | — (vault-owned subscription) | `aws_sqs_queue.connection_events` in aws/infra_secrets.tf; `CONNECTION_EVENTS_QUEUE_DSN` = SQS URL |
+| `servicebus-queue-vault-connection-events` | Service Bus queue (Azure) | — (vault-owned subscription) | `azurerm_servicebus_queue.connection_events` in azure/infra_secrets.tf; `CONNECTION_EVENTS_QUEUE_DSN` = Service Bus DSN |
+| `pubsub-sub-vault-connection-events` | Pub/Sub subscription (GCP) | — (vault-owned subscription) | `google_pubsub_subscription.connection_events` subscribing to `var.connection_events_pub_sub_name` in gcp/main.tf; filter: `storage.devBranchDeleted` only |
+
+## Unresolved
+None.
+
+## Notes
+- Each cloud variant creates its own queue resource for vault's connection events subscription — AWS creates an SQS queue, Azure a Service Bus queue, GCP a Pub/Sub subscription on Connection's topic. These are not shared with other services.
+- The GCP module filters the subscription to `storage.devBranchDeleted` only, unlike AWS/Azure which may receive all connection events and filter in the consumer.
+- No KMS/Key Vault dependency — vault does not use `Keboola\ObjectEncryptor`.

--- a/plugins/developer/skills/keboola-architecture/references/c4/list of services.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/list of services.md
@@ -1,0 +1,35 @@
+Updated **final inventory — 30 containers:**
+
+| Container | C4 ID | Repository/ies | Language | API | Notes |
+|---|---|---|---|---|---|
+| CONNECTION | `connection` | `connection` | PHP | [Storage API](https://keboola.docs.apiary.io/) · [Management API](https://api.keboola.com/?service=manage#overview) | Monolith; includes Storage + Management (`/manage`); authorization used by everyone |
+| UI | `ui` | `ui` | TypeScript | — | Frontend monorepo |
+| API SERVICE | `api` | `api-service` | TypeScript | — | Static SPA serving OpenAPI docs; no runtime dependencies |
+| QUEUE | `queue` | `job-queue`, `job-queue-daemon`, `job-runner` | PHP | [Queue API](https://app.swaggerhub.com/apis-docs/keboola/job-queue-api) | Includes docker-runner, internal API, gelf-logger-server |
+| SYNC ACTIONS | `sync-actions` | `runner-sync-api` | PHP | [Sync Actions API](https://app.swaggerhub.com/apis/odinuv/sync-actions) | |
+| SANDBOXES | `sandboxes` | `sandboxes-service`, `keboola-as-code`, `keboola-operator`, `sandboxes` | PHP/Go | [Sandboxes API](https://data-science.keboola.com/docs/swagger.yaml) | Four sub-systems: sandboxes-service (PHP REST API), apps-proxy (Go, keboola-as-code), keboola-operator (Go K8s operator), sandboxes component (ephemeral PHP job) |
+| STREAM | `stream` | `keboola-as-code` | Go | [Stream API](https://stream.keboola.com/v1/documentation/) | cmd/stream in keboola-as-code monorepo |
+| TEMPLATES | `templates` | `keboola-as-code` | Go | [Templates API](https://templates.keboola.com/v1/documentation/) | cmd/templates-api in keboola-as-code monorepo |
+| CLI | `cli` | `keboola-as-code` | Go | — | cmd/kbc in keboola-as-code monorepo; client-side tool, not a server |
+| MCP SERVER | `mcp-server` | `mcp-server` | Python | [MCP docs](https://developers.keboola.com/integrate/mcp/) | `mcp-server-agent` is same image, two deployments; open source |
+| AI | `ai` | `ai-service` | PHP | [AI API](https://ai.keboola.com/docs/swagger.yaml) | |
+| KAI ASSISTANT | `kai-assistant` | `ai-chat`, `ui` | TypeScript | — | Three apps: ai-chat, kai-assistant (BFF), kai-agent |
+| EDITOR | `editor` | `editor-service` | PHP | [Editor API](https://editor.keboola.com/docs/swagger.yaml) | |
+| OMNISEARCH | `omnisearch` | `omnisearch-and-metadata-engine` | Python | — (FastAPI, self-hosted) | Lineage + metadata engine; serves at metastore.{suffix}; internally "Impact AI" |
+| IMPORT | `import` | `sapi-importer` | PHP | [Importer API](https://app.swaggerhub.com/apis-docs/keboola/import) | |
+| OAUTH | `oauth` | `oauth-api`, `oauth-service`, `oauth-api-serverless` | JS/PHP | [OAuth Broker API](https://oauthapi3.docs.apiary.io/) | 3 versions in parallel |
+| ENCRYPTION | `encryption` | `encryption-api` | PHP | [Encryption API](https://keboolaencryption.docs.apiary.io/) | |
+| VAULT | `vault` | `vault` | PHP | [Vault API](https://vault.keboola.com/docs/swagger.yaml) | Variables & credentials storage |
+| NOTIFICATION | `notification` | `notification-service` | PHP | [Notifications API](https://app.swaggerhub.com/apis/odinuv/notifications-service) | |
+| BILLING | `billing` | `billing-api` | PHP | [Billing API](https://keboolabillingapi.docs.apiary.io/) | |
+| SCHEDULER | `scheduler` | `scheduler` | PHP | [Scheduler API](https://app.swaggerhub.com/apis/odinuv/scheduler) | |
+| QUERY | `query` | `go-monorepo` | Go | [Query API](https://query.keboola.com/api/v1/documentation) | services/query; AES encryption (not cloud KMS) |
+| METASTORE | `metastore` | `go-monorepo` | Go | — | services/metastore; gated on `metastore_enabled`; implemented but not enabled |
+| GIT SERVICE | `git-service` | `go-monorepo` | Go | — | services/git-service; wraps Forgejo; not yet commissioned |
+| FORGEJO | `forgejo` | — (upstream Bitnami Helm chart) | — | — | Self-hosted Git; not yet commissioned |
+| NATS | `nats` | — | — | — | kbc-stacks chart has no templates; not yet commissioned |
+| SKILL REGISTRY API | `skill-registry` | `skill-registry-api` | PHP | — | PHP/Symfony + React frontend; own auth (X-API-TOKEN), no Connection dependency; OAuth broker for GitHub/Google/HubSpot/Slack/Salesforce; deployed on canary-orion only |
+| SKILL REGISTRY MCP SERVER | `skill-registry-mcp-server` | `skill-registry-mcp-server` | Python | — | Python MCP server; calls Skill Registry API; kbc-stacks chart has no templates |
+| ELASTICSEARCH | `connection-elasticsearch`, `job-queue-elasticsearch` | — | — | — | Two self-hosted instances; no source repo |
+| DEVELOPER PORTAL | — | `developer-portal`, `developer-portal-ui` | JavaScript | [Developer Portal API](https://kebooladeveloperportal.docs.apiary.io/) | Satellite system |
+| TELEMETRY | — | `telemetry-raw-projects`, `telemetry-billing-gcp`, `embed-telemetry`, `gooddata-cn-provisioning` | — | — | Satellite system |

--- a/plugins/developer/skills/keboola-architecture/references/c4/model/model.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/model/model.dsl
@@ -1,0 +1,145 @@
+model {
+
+    # -------------------------------------------------------------------------
+    # People / Personas
+    # -------------------------------------------------------------------------
+
+    dataEngineer = person "Data Engineer" "Builds and maintains data pipelines, components, and platform foundations."
+    dataAnalyst  = person "Data Analyst" "Explores and consumes data for business insights. Can be any business role (CFO, marketing, etc.)."
+    developer    = person "Developer" "Builds and publishes Keboola components via the Developer Portal. Also uses the platform directly."
+    endUser      = person "End User" "Consumes Data Apps built on the Keboola platform. May have no awareness of Keboola itself."
+
+    # -------------------------------------------------------------------------
+    # External Systems (cloud vendor aggregates + SaaS)
+    # -------------------------------------------------------------------------
+
+    !include ../l3/external-systems.dsl
+
+    # -------------------------------------------------------------------------
+    # Named Cloud Resource Instances
+    # -------------------------------------------------------------------------
+
+    !include ../l3/cloud-resources.dsl
+
+    # -------------------------------------------------------------------------
+    # L1 Software Systems
+    # -------------------------------------------------------------------------
+
+    keboolaPlatform = softwareSystem "Keboola Platform" "Multi-tenant data platform providing storage, pipelines, workspaces, AI tooling and more. Deployed as independent stacks per region and cloud provider." {
+        !include ../l2/containers.dsl
+
+        # L3 inter-service relationships
+        !include ../l3/ai-service.dsl
+        !include ../l3/editor-service.dsl
+        !include ../l3/runner-sync-api.dsl
+        !include ../l3/scheduler.dsl
+        !include ../l3/job-queue.dsl
+        !include ../l3/job-queue-daemon.dsl
+        !include ../l3/encryption-api.dsl
+        !include ../l3/omnisearch-service.dsl
+        !include ../l3/vault.dsl
+        !include ../l3/connection.dsl
+        !include ../l3/billing-api.dsl
+        !include ../l3/notification-service.dsl
+        !include ../l3/sapi-importer.dsl
+        !include ../l3/oauth-service.dsl
+        !include ../l3/mcp-server.dsl
+        !include ../l3/templates-api.dsl
+        !include ../l3/stream.dsl
+        !include ../l3/kai-assistant.dsl
+        !include ../l3/api-service.dsl
+        !include ../l3/query-service.dsl
+        !include ../l3/git-service.dsl
+        !include ../l3/metastore-service.dsl
+        !include ../l3/sandboxes-service.dsl
+
+        # skill-registry: intra-system relationship (no L3 file -- uncommissioned, no Terraform)
+        skill-registry-mcp-server -> skill-registry "reads registered skills and executes them (KBC_SKILL_REGISTRY_URL)"
+    }
+
+    developerPortal = softwareSystem "Developer Portal" "Satellite system for component developers. Manages component registration and publishing. Loosely synchronized with each Keboola stack." {
+        devPortalWeb = container "Developer Portal Web" "UI for browsing and managing components." "JavaScript" {
+            url "https://github.com/keboola/developer-portal-ui"
+        }
+        devPortalApi = container "Developer Portal API" "REST API for component registration and management." "JavaScript" {
+            url "https://github.com/keboola/developer-portal"
+        }
+    }
+
+    telemetry = softwareSystem "Telemetry" "Satellite system built on top of the platform. Collects and exposes usage data to end users and drives billing calculations." {
+        telemetryRaw        = container "Telemetry Raw Projects" "Collects raw project-level telemetry data." "" {
+            url "https://github.com/keboola/telemetry-raw-projects"
+        }
+        telemetryBillingGcp = container "Telemetry Billing GCP" "GCP-specific billing telemetry pipeline." "" {
+            url "https://github.com/keboola/telemetry-billing-gcp"
+        }
+        embedTelemetry      = container "Embed Telemetry" "Embeds telemetry data into the platform UI." "" {
+            url "https://github.com/keboola/embed-telemetry"
+        }
+        gooddataCn          = container "GoodData CN Provisioning" "GoodData Cloud Native provisioning for telemetry outputs." "" {
+            url "https://github.com/keboola/gooddata-cn-provisioning"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # L1 Relationships — personas
+    # -------------------------------------------------------------------------
+
+    dataEngineer -> keboolaPlatform "Builds pipelines, manages components, runs jobs, uses Workspaces and SQL Editor"
+    dataEngineer -> telemetry       "Monitors pipeline performance and resource usage"
+    dataAnalyst  -> keboolaPlatform "Explores and queries data, consumes reports and dashboards"
+    dataAnalyst  -> telemetry       "Consumes telemetry-derived reports"
+    endUser      -> keboolaPlatform "Consumes Data Apps"
+    developer    -> keboolaPlatform "Tests and runs components, manages configurations"
+    developer    -> developerPortal "Registers and publishes components"
+
+    telemetry       -> keboolaPlatform "Uses Storage API and Jobs to collect and process telemetry data"
+    keboolaPlatform -> telemetry       "Feeds usage events; billing figures flow back into platform billing"
+
+    # L1 Relationships — cloud vendors
+    keboolaPlatform -> aws       "Runs on, stores data in, and encrypts with AWS services"
+    keboolaPlatform -> azure     "Runs on, stores data in, encrypts with, and uses AI from Azure services"
+    keboolaPlatform -> gcp       "Runs on, stores data in, and encrypts with GCP services"
+    keboolaPlatform -> datadog   "Ships metrics, traces, logs, and APM telemetry from all services"
+    keboolaPlatform -> langsmith "Ships LLM call traces from KAI apps (ai-chat, kai-assistant, kai-agent)"
+    keboolaPlatform -> snowflake "Uses as a customer data warehouse backend"
+    keboolaPlatform -> bigquery  "Uses as a customer data warehouse backend"
+    keboolaPlatform -> synapse   "Uses as a customer data warehouse backend"
+    keboolaPlatform -> exasol    "Uses as a customer data warehouse backend"
+    keboolaPlatform -> supabase  "Uses as a customer data warehouse backend (BYODB)"
+    keboolaPlatform -> sendgrid  "Sends transactional emails via SMTP relay"
+    keboolaPlatform -> stripe    "Processes pay-as-you-go credit purchases"
+    keboolaPlatform -> azure-marketplace  "Manages PAYG subscriptions and reports metered usage (Azure stacks)"
+    keboolaPlatform -> google-marketplace "Manages PAYG entitlements and consumes marketplace events (GCP stacks)"
+    keboolaPlatform -> github    "Clones template repositories at runtime to read template definitions (templates-api)"
+    keboolaPlatform -> e2b       "Executes sandboxed code via E2B (kai-agent, keboola-operator)"
+
+    # -------------------------------------------------------------------------
+    # L3 External relationships
+    # -------------------------------------------------------------------------
+
+    !include ../l3/ai-service-external.dsl
+    !include ../l3/editor-service-external.dsl
+    !include ../l3/runner-sync-api-external.dsl
+    !include ../l3/scheduler-external.dsl
+    !include ../l3/job-queue-external.dsl
+    !include ../l3/job-queue-daemon-external.dsl
+    !include ../l3/encryption-api-external.dsl
+    !include ../l3/omnisearch-service-external.dsl
+    !include ../l3/vault-external.dsl
+    !include ../l3/connection-external.dsl
+    !include ../l3/billing-api-external.dsl
+    !include ../l3/notification-service-external.dsl
+    !include ../l3/sapi-importer-external.dsl
+    !include ../l3/oauth-service-external.dsl
+    !include ../l3/mcp-server-external.dsl
+    !include ../l3/templates-api-external.dsl
+    !include ../l3/stream-external.dsl
+    !include ../l3/kai-assistant-external.dsl
+    !include ../l3/api-service-external.dsl
+    !include ../l3/query-service-external.dsl
+    !include ../l3/git-service-external.dsl
+    !include ../l3/metastore-service-external.dsl
+    !include ../l3/sandboxes-service-external.dsl
+
+}

--- a/plugins/developer/skills/keboola-architecture/references/c4/service-knowledge.md
+++ b/plugins/developer/skills/keboola-architecture/references/c4/service-knowledge.md
@@ -1,0 +1,845 @@
+# C4 Architecture — Service-Specific Knowledge
+
+This file contains knowledge about specific Keboola repositories that cannot be
+automatically detected from Terraform, kbc-stacks, or services.yaml sources. It
+is referenced by the analyze-service skill during scanning (Step 0).
+
+The file has two parts:
+
+1. **Per-service entries** (sorted alphabetically by GitHub repository name) —
+   non-obvious facts and quirks specific to one repository or service.
+2. **Architecture-wide conventions** — modelling decisions and patterns that
+   apply across the platform. The skill files refer to these instead of restating
+   them; the analyzer should always read them in addition to the per-service entry.
+
+**What does NOT belong here:** pure enumerations of facts already encoded in the C4
+model (`l3/*.dsl`, `l3/cloud-resources.dsl`, `model/model.dsl`, `views/views.dsl`).
+The model is the source of truth for what elements exist, which relationships are
+modelled, and how things are tagged. Maintaining parallel lists in this file creates
+drift — if an analyzer can derive the answer with `grep` over the DSL files, do not
+duplicate it here. Tables with substantial non-model context (rationale, source-code
+references, naming conventions, behavioural quirks) are fine; tables that just
+enumerate model edges are not.
+
+**What DOES belong here:** the *why* behind modelling decisions, non-obvious
+behaviours that a Terraform / Helm / source scan would miss, naming quirks (repo
+name ≠ chart name ≠ image name), deprecated patterns to ignore, scanning hints, and
+the rationale for architecture-wide conventions.
+
+The intent is to keep this knowledge here temporarily until it can be moved into
+each repository's own documentation; the architecture-wide conventions will
+eventually become an ADR.
+
+---
+
+## ai-chat / kai-assistant / kai-agent (repo: keboola/ai-chat + keboola/ui)
+
+### Three apps, one Terraform module — the naming mess explained
+
+Three independently deployed apps, all provisioned by the same Terraform module
+(`app-ai-chat`) with different `namespace` values. There is no separate `app-kai-assistant`
+or `app-kai-agent` Terraform module — searching for those will find nothing.
+
+| kbc-stacks chart | namespace | Source repo | Framework |
+|---|---|---|---|
+| `ai-chat` | `ai-chat` | `keboola/ai-chat` | Next.js |
+| `kai-assistant` | `kai-assistant` | `keboola/ui` (`apps/kai-assistant-backend`) | Next.js BFF |
+| `kai-agent` | `kai-agent` | `keboola/ui` (`apps/kai-agent`) | **Hono** (not Next.js) |
+
+Repo name ≠ image name ≠ chart name ≠ product name. When scanning, always look up the
+chart name in kbc-stacks, not the GitHub repo name.
+
+### How to find their Terraform config
+
+All three point to `source = "../../modules/app-ai-chat/aws|azure|gcp"`.
+Stack-level wiring: `aws/stage-30/app_ai_chat.tf`, `app_kai_assistant.tf`, `app_kai_agent.tf`.
+The module has three cloud variants (aws/, azure/, gcp/) — read all three for the full picture.
+
+### Shared vs per-app resources
+
+**Shared (one instance, three databases):**
+- PostgreSQL (`postgresql-instance`): one shared PostgreSQL instance, databases `ai_chat`,
+  `kai_assistant`, `kai_agent` initialized by the `kubernetes-postgresql-init` module.
+  See "Managed databases — collapsed across cloud providers" in the architecture-wide
+  conventions section for why this element has no provider tag.
+
+**Per-app (separate resource per namespace):**
+- Object storage: S3 (AWS) / Azure Blob Storage (Azure) / GCS (GCP) — one bucket/account per app.
+- GCP KMS key (GCP only): `google_kms_crypto_key.ai_chat_encryption` — used for GCS bucket
+  encryption at rest only (not application-level). No AWS/Azure KMS equivalent for these apps.
+
+### Cloud LLM provider — varies by cloud stack
+
+- AWS + GCP stacks: Google Vertex AI (`GOOGLE_SERVICE_ACCOUNT_JSON`, `GOOGLE_VERTEX_LOCATION`,
+  `GOOGLE_VERTEX_PROJECT`)
+- Azure stacks: Azure AI Foundry (`FOUNDRY_API_ENDPOINT`, `FOUNDRY_API_KEY`,
+  `FOUNDRY_DEPLOYMENT_NAME`, `FOUNDRY_MODEL_NAME`). Toggled via `CLOUD_LLM_PROVIDER` env var.
+
+Both are modelled as `CloudResource`-tagged named instances (not Vendor aggregates) since they
+are specific managed AI platform deployments.
+
+### kai-agent only: E2B
+
+`kai-app-kai-agent` is the only component using E2B (`E2B_API_KEY`, `@e2b/code-interpreter`).
+E2B is an external SaaS vendor for sandboxed code execution. It is tagged `"Vendor"` and
+appears on the **L1 system context view** as a platform-level external dependency, alongside
+SendGrid, Stripe, and GitHub.
+
+### ai-chat only: Keboola OAuth and OAuth token refresh
+
+`kai-app-ai-chat` has `KEBOOLA_OAUTH_CLIENT_ID` / `KEBOOLA_OAUTH_CLIENT_SECRET` — it uses
+the platform's OAuth service for user authentication. The other two apps use direct Storage
+token auth. This is visible in ai-chat's `secret.yaml` vs the other two.
+
+After initial OAuth login, `ai-chat` also calls `KEBOOLA_OAUTH_HOST/oauth/token` with
+`grant_type=refresh_token` to refresh expired access tokens (lib/db/tokens.ts:
+`refreshKeboolaToken`). This is a direct HTTP call to Connection (`connection.{suffix}`)
+using the OAuth client credentials. The relationship is already modelled as
+`kai-app-ai-chat -> connection`.
+
+### TOKEN_ENCRYPTION_KEY — application-managed symmetric encryption
+
+`TOKEN_ENCRYPTION_KEY` is a 32-byte AES-GCM key (base64-encoded) injected as an infra secret.
+It is used by `lib/crypto/token-encryption.ts` via the Web Crypto API (`crypto.subtle`) to
+encrypt Keboola OAuth access tokens and refresh tokens before storing them in PostgreSQL.
+This is called on every OAuth login (`storeKeboolaTokens`) and every API request
+(`getValidKeboolaToken` -> `safeDecryptToken`).
+
+This is application-managed encryption, NOT cloud KMS — see "Application-managed encryption"
+in architecture-wide conventions. Do NOT add a `kms-key-ai-chat-aws/azure` C4 cloud resource
+relationship for this.
+
+### Redis — non-production, do not model
+
+Both `ai-chat` and `kai-assistant-backend` list `redis` in `package.json` dependencies, but
+Redis is NOT present in any Terraform infra secrets or kbc-stacks secret templates.
+Confirmed non-production. Do not add a Redis resource or relationship.
+
+### LangSmith — observability only, do not model
+
+`LANGCHAIN_API_KEY` / `LANGSMITH_API_KEY` appear in all three apps' secrets. LangSmith is an
+LLM observability/tracing tool equivalent to Datadog for AI workflows. See "Observability
+tooling" in architecture-wide conventions.
+
+### C4 element IDs
+
+Container: `kai-assistant`
+Components: `kai-app-ai-chat`, `kai-app-kai-assistant`, `kai-app-kai-agent`
+L3 files: `kai-assistant.dsl`, `kai-assistant-external.dsl`, `kai-assistant.md`
+
+---
+
+## ai-service
+
+### appSecrets ENV mappings
+| ENV key | Target container ID | Notes |
+|---|---|---|
+| `PROMPT_RECORD_URL` | `stream` | Stream service ingest endpoint for recording prompts |
+| `FEEDBACK_RECORD_URL` | `stream` | Stream service ingest endpoint for recording feedback |
+
+---
+
+## connection
+
+### Three distinct APIs — one deployed process
+The `connection-api` Deployment serves three logically separate APIs via Zend front controller routing:
+
+| Component ID | Route prefix | Auth scope | Purpose |
+|---|---|---|---|
+| `connection-storage-api` | `/v1`, `/v2` | Storage token (project-scoped) | Core data-plane: buckets, tables, files, tokens, events, configurations, workspaces, dev branches |
+| `connection-manage-api` | `/manage` | Manage token (org-scoped) | Projects, organisations, maintainers, storage backends, users, platform metadata |
+| `connection-payg-api` | `/pay-as-you-go` | Session/super token | PAYG billing: Stripe payments, credits, top-up config, registration wizard |
+
+Route registration: `Bootstrap.php::_initRoutes()` — Storage via `Storage_Service_RouteFactory`,
+Manage via `Manage_Service_RouteFactory`, PAYG as the `pay-as-you-go` Zend module.
+
+### Relationship assignment by component
+- Storage backends (Snowflake, BigQuery, etc.) -> `connection-storage-api`
+- Cloud queues and event topics (SQS, SNS, Service Bus, Event Grid, Pub/Sub) -> `connection-storage-api`
+- Cloud file storage (S3, ABS, GCS) -> `connection-storage-api`
+- Cloud databases (RDS, Azure DB, Cloud SQL) -> both `connection-storage-api` and `connection-manage-api` (shared MySQL)
+- Stripe -> `connection-payg-api` (billing layer)
+- Sandboxes API -> `connection-manage-api` (CLI maintenance commands)
+- Queue Public API -> `connection-worker-triggers` (table trigger fires component jobs)
+
+### SendGrid — used by all three APIs and the certificate-rotation worker
+
+SendGrid is NOT exclusively manage-api. All three Connection APIs and the certificate-rotation
+worker send email:
+
+| Component | Email type | Source class |
+|---|---|---|
+| `connection-storage-api` | Token sharing, merge request lifecycle notifications | `ShareTokenService`, `MergeRequestEmails` |
+| `connection-manage-api` | Project invitations, Snowflake Partner Connect welcome | `ProjectsService`, `SPCSingleEmailService` |
+| `connection-payg-api` | PAYG registration welcome email | `pay-as-you-go/service/Project.php` |
+| `connection-worker-certificate-rotation` | SAML2 certificate expiry warnings to backend technical owners | `Saml2CertificateRotationEmails` |
+
+All go through the same `email.transport` (`Zend_Mail_Transport_Abstract` / `EmailSender`).
+Model four separate `-> sendgrid` relationships in `connection-external.dsl`.
+
+### Scheduler-based workers — how to find their dependencies
+
+The three workers `connection-worker-user-tasks-scheduler`, `connection-worker-monitoring`,
+and `connection-worker-certificate-rotation` do NOT use Symfony Messenger transports in the
+standard sense. They use the Symfony Scheduler component (`symfony/scheduler`), which
+registers tasks via PHP attributes rather than `messenger.yaml`. The string after
+`messenger:consume` in `values.yaml` (e.g. `scheduler_monitoring`) is the name of the
+scheduler schedule, not a queue name. To find what a scheduler worker does:
+
+1. Search the codebase for `#[AsCronTask(schedule: '<name>')]` or `#[AsSchedule('<name>')]`
+   matching the schedule name (strip the `scheduler_` prefix).
+2. The PHP class bearing that attribute is the command/handler that runs under this worker.
+   Read that class to determine its dependencies.
+
+Mapping of workers to source:
+
+| Worker | Schedule name | Source class |
+|---|---|---|
+| `connection-worker-user-tasks-scheduler` | `user_tasks` | `ScheduledTaskProvider` |
+| `connection-worker-monitoring` | `monitoring` | `StorageBackendHealthCheckCommand` |
+| `connection-worker-certificate-rotation` | `certificate-rotation` | `CheckSaml2CertificatesExpirationCommand`, `RefreshCertificateForProject`, `RefreshCertificateForBackend` |
+
+`user_tasks`: Reads `ScheduledTask` entities from MySQL, enqueues storage jobs. Dependencies: MySQL + cloud queues.
+`monitoring`: Live connection tests to Snowflake/BigQuery backends. Dependencies: MySQL + Snowflake + BigQuery.
+`certificate-rotation`: Direct DDL on customer Snowflake accounts + SAML2 certificate expiry emails. Dependencies: MySQL + Snowflake + SendGrid.
+
+### connection-cronjob-project-purge-scheduler — enqueues via internal commands queue
+
+`ProjectPurgeScheduler` calls `CommandsService.enqueueCommand('storage:project-purge', [...])` which
+dispatches to `QueueServiceInterface::QUEUE_COMMANDS` — the `connection-commands` queue
+(SQS/Service Bus/Pub/Sub), consumed by `connection-worker-commands`.
+
+C4 relationships: `-> mysql-instance-connection` (reads projects) +
+`-> sqs/servicebus/pubsub-queue-connection-commands` (enqueues purge commands).
+
+### connection-cronjob-token-expiration — MySQL only
+
+`TokenExpirator` performs pure MySQL operations: deletes expired storage/manage tokens, expired
+project-admin associations, expired invitations, expired join requests, and admin sessions.
+No external service calls. Only dependency: `mysql-instance-connection`.
+
+### connection-cronjob-release-staled-locks — uses K8s API
+
+The only Connection component that calls the Kubernetes API at the application level. Lists
+pods to identify stale locks held by terminated/failed worker pods, then releases them.
+Matches the rule in the "Kubernetes clusters" architecture-wide convention; modelled with
+`-> aws-eks/azure-aks/gcp-gke`. This is the only Keboola service outside `queue` and
+`sandboxes` to touch K8s, which is why it's worth flagging here.
+
+### Connection internal queues — real SQS/Service Bus/Pub/Sub resources
+
+Connection owns 7 internal queues provisioned by its own Terraform module
+(`app-connection/aws/queue_*.tf`, `app-connection/azure/messaging.tf`, `app-connection/gcp/messaging.tf`).
+All are Pattern A (Connection both publishes and its workers consume).
+
+| Logical name (QueueServiceInterface const) | C4 resource ID prefix | Consumer component |
+|---|---|---|
+| `main` (QUEUE_MAIN) | `*-queue-connection-main` | `connection-worker-main` |
+| `commands` (QUEUE_COMMANDS) | `*-queue-connection-commands` | `connection-worker-commands` |
+| `eventsElastic` (QUEUE_EVENTS_ELASTIC) | `*-queue-connection-events-elastic` | `connection-worker-events-elastic` |
+| `auditLog` (QUEUE_AUDIT_LOG) | `*-queue-connection-worker-audit-log` | `connection-worker-audit-log` |
+| `tableTriggers` (QUEUE_TABLE_TRIGGERS) | `*-queue-connection-table-triggers` | `connection-worker-triggers` |
+| `searchIndex` (QUEUE_SEARCH_INDEX) | `*-queue-connection-search-index` | `connection-worker-search-index` |
+| `jobStats` (QUEUE_JOB_STATS) | *(provisioned but unused)* | — |
+
+Note: `main` queue is also written to by `connection-worker-user-tasks-scheduler` (scheduled tasks).
+Note: `commands` queue is also written to by `connection-cronjob-project-purge-scheduler`.
+
+**Important — audit-log ID uses `-worker-` infix:** The internal audit-log queue C4 IDs are
+`sqs/servicebus/pubsub-topic-connection-worker-audit-log`. This distinguishes them from the
+cross-service `sns/eventgrid/pubsub-topic-connection-audit-log` fan-out topics. The `-worker-`
+infix was necessary to avoid an ID clash in Structurizr.
+
+### Connection internal SNS/EventGrid topics are NOT cross-service fan-out
+
+Connection has three internal SNS topics on AWS (and equivalents on Azure/GCP):
+- `SNS__EVENTS_TOPIC__ARN` (`events_topic.tf`) — fans out to `QueueEventsElastic` and `QueueTableTriggers` (both internal)
+- `SNS__AUDIT_LOG_EVENTS_TOPIC__ARN` (`audit_log_topic.tf`) — fans out to `QueueAuditLogEvents` (internal)
+- `SNS__SEARCH_INDEX_TOPIC__ARN` (`search_index_topic.tf`) — internal
+
+All three are internal SNS->SQS delivery mechanisms within Connection only. They are NOT the
+cross-service `sns-topic-connection-events` / `sns-topic-connection-audit-log` topics.
+
+The cross-service SNS topics are provisioned in Connection's Terraform and their ARNs are passed
+as output variables to subscriber service Terraform modules. Subscriber services (editor, vault,
+oauth) provision their own SQS queues and subscribe via `aws_sns_topic_subscription` in their
+own `queue_connection.tf` files.
+
+**Scanning implication:** When scanning editor/vault/oauth Terraform, `var.connection_events_topic_arn`
+and `var.connection_audit_log_topic_arn` reference Connection's cross-service topics. The
+subscriber-owned SQS queues (e.g. `sqs-queue-editor-connection-events`) are C4 named resources
+owned by the subscriber service, not by Connection.
+
+### connection-cronjob-sync-apps — inter-stack dependency (unusual)
+`ui-apps:sync` calls `GET /manage/ui-apps` on a configurable host (default: `https://connection.keboola.com`)
+via `GuzzleClient`. This is an **inter-stack dependency** — a running Connection stack calling a different
+Connection stack (the reference/production stack) to fetch canonical UI app definitions.
+
+This is architecturally unusual: it is the only place in the platform where a service on one stack makes
+a runtime HTTP call to a hardcoded URL on another stack. It is NOT modelled as an inter-service dependency
+(there is no C4 element for "another Connection stack"). The only relationship modelled is:
+`connection-cronjob-sync-apps -> mysql-instance-connection` (writes the synced app definitions locally).
+
+Do NOT add a self-referential relationship or a relationship to `connection` from `connection-cronjob-sync-apps`.
+
+### keboolaServices parameter — three actual getService call sites
+The `%keboolaServices%` Symfony parameter is internally consumed via `stackInfo->getService(key)` in
+exactly three non-test production files:
+
+| File | Key | Client | Nature |
+|---|---|---|---|
+| `EventTriggerFactory.php` | `'queue'` | `Keboola\JobQueueClient\Client` | Runtime — every table trigger fire |
+| `DefaultSandboxManageClientFactory.php` | `'sandboxes'` | `Keboola\Sandboxes\Api\ManageClient` | CLI — Snowflake hostname change command |
+| `ResetSandboxesPasswordForProject.php` | `'sandboxes'` | `Keboola\Sandboxes\Api\ManageClient` | CLI — BYODB migration tool |
+
+The `oauth`, `import`, `syrup` keys are never consumed via `getService` internally — pass-through only.
+Do not model as inter-service dependencies.
+
+### Storage backends
+- Snowflake — Active. BigQuery — Active. Synapse — Legacy. Exasol — Legacy. Supabase — Uncommissioned.
+
+Model `synapse` and `exasol` with `"Legacy"` tag, `supabase` with `"Uncommissioned"` tag.
+
+### Developer Portal sync
+`connection-cronjob-sync-components` (`storage:component:sync-dev-portal`) fetches component
+definitions from `devPortal.url` via `Keboola\DeveloperPortal\Client`, then writes them to
+the `apis` MySQL table via `Model_Apis::replace()`.
+
+Dependencies: `devPortalApi` (read) + `mysql-instance-connection` (write).
+
+The `devPortalApi` relationship must be in `connection-external.dsl` (top-level model), not
+`connection.dsl` (inside keboolaPlatform), because `devPortalApi` is outside `keboolaPlatform`.
+The MySQL relationship is also in `connection-external.dsl` alongside the rest of the MySQL entries.
+
+### Stripe
+`PayAsYouGo_Service_Stripe` for credit top-ups. Model as `connection-payg-api -> stripe`.
+
+### Elasticsearch — Helm-managed, not Terraform
+Elasticsearch config is injected at deploy-time by the elasticsearch chart cert-copy job.
+Not in Terraform infra_secrets.
+
+### No KMS dependency
+Connection uses its own symmetric `ENCRYPTION_KEYS__*` env vars. Does NOT use
+`Keboola\ObjectEncryptor` / cloud KMS. See "Application-managed encryption" in
+architecture-wide conventions.
+
+---
+
+## go-monorepo (services/query)
+
+### Single Terraform module variant — no aws/azure/gcp split
+
+`app-query-service` has only a single `main.tf` (no aws/, azure/, gcp/ subdirectories).
+This is because the module only creates a K8s namespace and injects PostgreSQL credentials
+from the shared `postgresql-instance`. No cloud-specific resources are needed.
+When scanning, do not expect cloud subdirectories — read `main.tf` directly.
+
+### Application-managed AES encryption
+
+`QUERY_ENCRYPTION_AES_SECRET_KEY` is a 32-byte AES-256 key injected via a dedicated
+Kubernetes Secret (`query-service-env-secrets`). Used by `internal/encryption` package
+(`go-cloud-encrypt`) to encrypt workspace credentials at rest in PostgreSQL.
+
+`config.go` explicitly validates `oneof=none aes` — there is no cloud KMS provider option
+in this service. The comment "Do not use in production" in the config struct refers to the
+AES provider being the simpler option, but AES is what is deployed (kbc-stacks hardcodes
+`QUERY_ENCRYPTION_PROVIDER=aes`).
+
+This is application-managed encryption, NOT cloud KMS — see "Application-managed encryption"
+in architecture-wide conventions. Do NOT add a cloud KMS resource relationship for this.
+
+### PostgreSQL queue — no inter-component HTTP calls
+
+The coordinator and workers communicate exclusively via PostgreSQL LISTEN/NOTIFY and
+partitioned job tables. There are no direct HTTP calls between `query-service-coordinator`
+and `query-service-worker`. All three Deployments (api, coordinator, worker) each get the
+full `QUERY_DB_*` credentials and connect directly to PostgreSQL independently.
+
+### Same binary, different args
+
+All components use a single Docker image from `go-monorepo`. Differentiated by `args`:
+- `api-deployment.yaml`: `args: ["api"]` — `/app/service`
+- `coordinator-deployment.yaml`: `args: ["coordinator"]` — `/app/service`
+- `worker-deployment.yaml`: `args: ["worker"]` — `/app/service`
+- `cronjob-partition-maintenance.yaml`: separate binary `/app/partition-maintenance`
+
+---
+
+## job-queue
+
+### Structure — monorepo with four deployment groups
+This is a monorepo (`https://github.com/keboola/job-queue`).
+The `queue` L2 container maps to four separately provisioned deployment groups.
+
+Group 1 — Public API (`apps/public-api`): single Deployment, sole external-facing component.
+
+Group 2 — Internal API (`apps/internal-api` + kbc-stacks `apps/job-queue-internal-api`):
+one Deployment plus CronJobs and Logstash. Always scan kbc-stacks templates directory.
+`INTERNAL_API_URL` is internal wiring within the `queue` container — NOT cross-container.
+
+Group 3 — Runner (`apps/service-container`, `apps/gelf-logger-server`,
+`apps/input-mapping-component`, `apps/output-mapping-component`, legacy `keboola/job-runner`):
+ephemeral per-job pods, no Terraform infra_secrets, credentials injected by daemon.
+service-container -> vault; gelf-logger-server -> connection. See `job-runner` section.
+
+Group 4 — Daemon (`keboola/job-queue-daemon`, separate repo). Scan separately.
+
+### Inter-service dependency rules
+- `queue-public-api` -> `connection`: via `STORAGE_API_URL` + `Keboola\StorageApiBranch` + `Keboola\ManageApi\Client`.
+- `queue-internal-api` -> `connection`: via `ServiceClient.getConnectionServiceUrl()`.
+- `queue-internal-api` -> `elasticsearch`: via `ELASTICSEARCH_URL` (self-hosted container — .dsl not -external.dsl).
+- Logstash -> `elasticsearch`: output plugin.
+- Replication check CronJob -> `elasticsearch`: checks lag.
+- Runner components -> `connection`: via `Keboola\StorageApiBranch`.
+- Runner components -> `vault`: via `Keboola\VaultApiClient`.
+- GELF logger -> `connection`: via `STORAGE_API_URL`.
+
+---
+
+## job-queue-daemon
+
+### Structure — data-driven deployments
+`templates/deployments.yaml` and `templates/cronjobs.yaml` iterate over `.Values` lists.
+Always read `values.yaml` to discover actual deployed components.
+
+### Inter-service dependency rules
+- `Keboola\JobQueueInternalClient\Client` with `DAEMON_INTERNAL_QUEUE_API_URL` -> `queue-internal-api`.
+- `Keboola\NotificationClient\*` -> `notification`.
+- `Keboola\BillingApi\ClientFactory` -> `billing` (conditional on `BILLING_ENABLED`, still model it).
+- `VAULT_API_URL` in `App\Daemon\RunnerConfigurationFactory` -> `vault`.
+- `Keboola\StorageApiBranch` + `Keboola\ManageApi\Client` using `STORAGE_API_URL_INTERNAL` -> `connection`.
+- `RUNNER_INTERNAL_QUEUE_API_URL` in `K8sManifestsFactory` — injected into spawned pods, NOT a daemon dependency.
+- DB/flow cleanup CronJobs -> `queue-internal-api`.
+- `daemon-cron-pod-cleanup` makes K8s API calls to delete orphaned pods. NOT a Keboola inter-service dependency — modelled as `-> aws-eks/azure-aks/gcp-gke` per the "Kubernetes clusters" architecture-wide convention.
+
+### External dependency rules
+- `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` — ECR auth, deprecated. Do NOT model as storage dependency.
+- `JOBS_TO_START_QUEUE_DSN`, `FLOW_JOBS_TRANSITION_QUEUE_DSN` — daemon-owned Pattern A queues.
+- `Keboola\ObjectEncryptor` uses the shared job-runner KMS key, NOT the `encryption` container.
+
+---
+
+## job-runner
+
+### Structure — per-job ephemeral container, not a persistent service
+No kbc-stacks entry, no Terraform module. Spawned per-job by daemon as ephemeral pod.
+Credentials injected by daemon via `App\Daemon\RunnerConfigurationFactory`.
+The ECS mention in README is outdated — runs in K8s.
+
+C4 modelling: component of `queue` container (Group 3). Component ID: `queue-job-runner`.
+
+### Inter-service dependency rules
+- `connection`: `STORAGE_API_URL` via `Keboola\StorageApiBranch`.
+- `queue` (internal-api): `JOB_QUEUE_URL` via `Keboola\JobQueueInternalClient\Client`.
+- `vault`: `VAULT_API_URL` via `Keboola\VaultApiClient\Variables\VariablesApiClient`.
+- `Keboola\ObjectEncryptor` -> shared job-runner KMS key, NOT the `encryption` container.
+
+No infra_secrets to scan — credentials are injected by daemon.
+
+---
+
+## keboola-as-code
+
+### No Terraform infrastructure — all config from ConfigMap
+
+`templates-api` has no Terraform module. No infra_secrets, no KMS keys, no cloud queues, no
+managed databases, no object storage. All config comes from a ConfigMap in kbc-stacks `_helpers.tpl`:
+- `TEMPLATES_STORAGE_API_HOST` = `https://connection.{hostnameSuffix}` (only inter-service dependency)
+- `TEMPLATES_API_PUBLIC_URL` = `https://templates.{hostnameSuffix}` (self-referential)
+
+Scanning Terraform will find nothing for this service. Go directly to kbc-stacks.
+
+### GitHub is an operational runtime dependency
+
+`templates-api` clones Git repositories at runtime to read template definitions.
+Hardcoded in `internal/pkg/template/repository/default.go`:
+- `https://github.com/keboola/keboola-as-code-templates.git` (main, beta, dev branches)
+- `ComponentsTemplateRepositoryURL` (main, beta branches)
+
+Model as `templates-api -> github` in `templates-api-external.dsl`. GitHub is a `Vendor`-tagged
+softwareSystem in `external-systems.dsl` and appears on the L1 system context view.
+
+### etcd is a co-deployed Helm sub-chart, not a separate service
+
+`templates-api-etcd` (3-replica Bitnami etcd) is a Helm sub-chart co-deployed with templates-api,
+not a separate kbc-stacks app. Model as a `SelfHosted`-tagged component inside the `templates`
+container. API degrades gracefully without it (loses write atomicity).
+
+---
+
+## mcp-server
+
+### All service URLs derived from storage_api_url — invisible to ENV scanning
+
+`mcp-server` has no Terraform module and no infra_secrets. All inter-service URLs are
+derived at runtime in `KeboolaClient.__init__` (`src/keboola_mcp_server/clients/client.py`)
+by replacing the `connection.` prefix with the target service prefix:
+
+| Python variable | URL pattern | C4 container |
+|---|---|---|
+| `queue_api_url` | `queue.{suffix}` | `queue` |
+| `ai_service_api_url` | `ai.{suffix}` | `ai` |
+| `encryption_api_url` | `encryption.{suffix}` | `encryption` |
+| `scheduler_api_url` | `scheduler.{suffix}` | `scheduler` |
+| `sync_actions_api_url` | `sync-actions.{suffix}` | `sync-actions` |
+| `metastore_api_url` | `metastore.{suffix}` | `metastore` |
+| `data_science_api_url` | `data-science.{suffix}` | `sandboxes` (see below) |
+| (in workspace.py) | `query.{suffix}` | `query` |
+
+Do NOT scan ENV or infra_secrets for inter-service dependencies — read `KeboolaClient.__init__` directly.
+
+### data-science.{suffix} maps to sandboxes container
+
+`DataScienceClient` at `data-science.{suffix}` is served by the `sandboxes` container.
+Model as: `mcp-server -> sandboxes`.
+
+### Self-hosted / local deployment — same code, different deployment context
+
+`mcp-server` is open-source and installable via `pip` or `uvx`. Only the hosted deployment
+(kbc-stacks) is modelled in C4. Do NOT add a separate C4 container for local/self-hosted.
+
+### mcp-server-agent — dedicated internal endpoint for kai-assistant
+
+`mcp-server-agent` is a separate Kubernetes Deployment (namespace `mcp-server-agent`, 2 replicas)
+using the same image but configured differently:
+
+| | `mcp-server` | `mcp-server-agent` |
+|---|---|---|
+| Transport | `--transport http-compat` | `--transport streamable-http` |
+| Auth | OAuth (KBC_OAUTH_CLIENT_ID/SECRET/JWT_SECRET) | None — caller passes Storage token directly |
+| Consumer | External AI agents (Cursor, Claude, Windsurf) | kai-assistant (internal) |
+| Replicas | 1 | 2 |
+
+C4 component IDs: `mcp-server-api` and `mcp-server-agent`. The `kai-assistant -> mcp-server-agent`
+relationship is in `mcp-server.dsl`.
+
+---
+
+## oauth-service
+
+### Legacy migration ENV keys — do not model
+
+`oauth-service` carries temporary cross-account dependencies for migrating data from legacy implementations.
+These are wired via `LEGACY_OAUTH_*` ENV keys and must NOT be modelled — marked as TEMPORARY in Terraform.
+The `oauth-service-legacy-oauth-migration` Job is a helm hook — skip when enumerating components.
+
+AWS keys: `LEGACY_OAUTH_DYNAMO_*`, `LEGACY_OAUTH_KMS_ARN` (cross-account DynamoDB + KMS from legacy Lambda).
+Azure keys: `LEGACY_OAUTH_COSMOSDB_*`, `LEGACY_OAUTH_KEY_VAULT_*` (Cosmos DB + Key Vault from legacy Node.js).
+
+### Three parallel implementations — two being phased out
+
+| Repo | Language | Status |
+|---|---|---|
+| `https://github.com/keboola/oauth-api` | Node.js | Being phased out |
+| `https://github.com/keboola/oauth-api-serverless` | Node.js | Being phased out |
+| `https://github.com/keboola/oauth-service` | PHP (Symfony) | Active/canonical |
+
+`oauth-service-serverless-proxy` is conditional nginx routing only — no service dependencies.
+Do NOT model it as a C4 component.
+
+All three repos in the `repos` property: `"oauth-api, oauth-service, oauth-api-serverless"`.
+
+### Cross-service Connection event subscription — how to find it in Terraform
+When scanning oauth-service (and similarly editor-service, vault), look for a
+`queue_connection.tf` file (or similar) in the AWS Terraform module. This file contains:
+- `aws_sqs_queue` resources for the subscriber-owned queues
+- `aws_sns_topic_subscription` pointing to `var.connection_events_topic_arn` (and/or
+  `var.connection_audit_log_topic_arn`)
+
+The topic ARN variables come from Connection's Terraform outputs. The SQS queues are owned by
+the subscriber service. This pattern is the same across all three subscriber services.
+
+---
+
+## omnisearch-and-metadata-engine
+
+### Queue dependency — non-obvious URL derivation
+`omnisearch-metastore-builder` calls `queue` via `QueueClient` in `metastore/impl.py`.
+Queue URL derived at runtime: `re.sub(r"((?<=/)|^)connection\.", "queue.", url)`
+This is invisible to ENV-only scanning.
+
+Dependency: `omnisearch-metastore-builder` -> `queue` (reads job history per configuration).
+`omnisearch-service-api` does NOT call queue — only the builder does.
+
+---
+
+## sandboxes-service (repos: keboola/sandboxes-service, keboola/keboola-as-code, keboola/keboola-operator, keboola/sandboxes)
+
+### Two distinct products — do not confuse them
+
+| Product | UI name | DNS | What manages it |
+|---|---|---|---|
+| Python/R sandboxes | Workspaces | `data-science.{suffix}` | sandboxes-service |
+| Data Apps | Apps | `data-science.{suffix}` | sandboxes-service |
+
+SQL Workspaces (SQL Editor) are managed exclusively by `editor-service`. Do NOT add SQL
+Workspace functionality to the sandboxes container.
+
+### sandboxes-api is removed — do not reference it
+
+`keboola/sandboxes-api` (Node.js) no longer exists. The canonical API is `sandboxes-service`
+(PHP/Symfony, repo `keboola/sandboxes-service`), served at `data-science.{suffix}`.
+
+### Four repos, three distinct roles
+
+| kbc-stacks app | Source | Language | Role |
+|---|---|---|---|
+| `sandboxes-service` | `keboola/sandboxes-service` | PHP | Central REST API; orchestrates provisioning |
+| `apps-proxy` | `keboola/keboola-as-code` (`cmd/apps-proxy`) | Go | Reverse proxy for Apps only; NOT in keboola-operator repo |
+| `keboola-operator` | `keboola/keboola-operator` | Go | K8s operator managing App/StorageToken/E2bSandbox CRDs |
+| *(job component)* | `keboola/sandboxes` | PHP | Ephemeral job pod run via job-queue |
+
+### apps-proxy is in keboola-as-code, not keboola-operator
+
+`apps-proxy` lives at `keboola-as-code/cmd/apps-proxy` — the same monorepo as stream,
+templates, and CLI. It is NOT part of `keboola-operator`. It is a standalone Deployment
+in kbc-stacks (`apps/apps-proxy`).
+
+apps-proxy has TWO K8s-related dependencies:
+1. `sandboxes-service-api`: app configuration and auth (via `APPS_PROXY_SANDBOXES_API_URL`)
+2. K8s API directly: watches App CRDs via `k8sapp.AppStateWatcher` (dynamic client)
+   to determine which pods are running and route traffic to them
+
+### Three provisioning paths for two products
+
+| Product | Standard path | Secondary | Uncommissioned |
+|---|---|---|---|
+| Workspaces (Python/R) | `sandboxes` component via job-queue | operator (phasing in) | — |
+| Apps | operator | `sandboxes` component (phasing out) | E2B |
+
+### sandboxes component is a job-queue component, not a service
+
+`keboola/sandboxes` (component ID: `keboola.sandboxes`) is not a persistent service.
+It runs as ephemeral job pods via the standard job-queue runner infrastructure — spawned
+by the daemon, exits on completion. It abuses the job-queue mechanism for async K8s
+operations. It has its own `keboola/k8s-client` dependency for direct K8s API access.
+Model as a `"Legacy"` component inside the `sandboxes` container.
+
+### keboola-operator has no Terraform module
+
+There is no `app-keboola-operator` Terraform module in the infrastructure repo.
+All operator config (API token, KMS key, E2B API key, etc.) is injected entirely via
+kbc-stacks `secret-config.yaml`. Do NOT look for Terraform infra_secrets for this service.
+
+### keboola-operator runs in-cluster — K8s is its raison d'être
+
+The operator uses `InClusterClientFacadeFactory` — it runs inside the K8s cluster.
+Unlike sandboxes-service (which calls K8s from outside as an external client), the
+operator IS part of the control plane. However, its K8s API usage IS still modelled as
+a `-> aws-eks/azure-aks/gcp-gke` dependency because it is the operator's entire purpose
+(managing App/StorageToken/E2bSandbox CRDs) — not the generic "runs-on" relationship.
+
+### Job-runner KMS key — cross-service decrypt dependency
+
+`sandboxes-service-api` uses `app.object_encryptor.job_queue` (the shared job-runner
+KMS key) to **decrypt** app OAuth/config secrets that were **encrypted by the job-queue
+component** using this shared key. This is a cross-service decrypt dependency — not
+sandboxes-service doing its own encryption.
+
+`keboola-operator` uses the same job-runner KMS key for the same reason: decrypting
+app configuration secrets when provisioning app pods.
+
+The service-owned KMS key (`kms-key-sandboxes-service-*`) is for sandboxes-service's
+own internal encryption of app configuration (separate purpose from the job-runner key).
+
+### Structurizr parent-child constraint
+
+`apps-proxy` and `sandboxes-component` are components inside the `sandboxes` container.
+Structurizr does NOT allow relationships between a component and its parent container.
+
+Therefore:
+- `apps-proxy -> sandboxes` is INVALID (parent-child)
+- `apps-proxy -> sandboxes-service-api` is CORRECT (component-to-component)
+- Same applies to `sandboxes-component -> sandboxes-service-api`
+
+### C4 element IDs
+
+Container: `sandboxes`
+Components: `sandboxes-service-api`, `sandboxes-service-garbage-collector`,
+  `sandboxes-service-messenger-consumer-connection-events`,
+  `sandboxes-service-messenger-consumer-connection-audit-log`,
+  `sandboxes-service-sync-app-runs-watch`, `sandboxes-service-suspend`,
+  `sandboxes-service-purge-app-runs`, `sandboxes-service-prune-app-run-logs`,
+  `apps-proxy`, `keboola-operator`, `sandboxes-component` (Legacy)
+L3 files: `sandboxes-service.dsl`, `sandboxes-service-external.dsl`, `sandboxes-service.md`
+
+---
+
+## Architecture-wide conventions
+
+These apply across all services. The skill files refer to this section instead of
+restating these rules. The analyzer should always read this section in addition to
+the per-service entry being scanned.
+
+### Managed databases — collapsed across cloud providers
+
+The MySQL and PostgreSQL instances (`mysql-instance-connection`, `mysql-instance-job-queue`,
+`postgresql-instance`) are modelled as cloud-neutral elements without `AWS`/`Azure`/`GCP`
+tags, even though each cloud stack hosts them on a different managed service: AWS RDS,
+Azure Database for MySQL/PostgreSQL, or Cloud SQL on GCP. This is intentional. Applications
+connect via cloud-agnostic `DB_*` environment variables (host, port, user, password,
+database name); they do not see — and do not need to know — which managed service is
+behind the connection string. Switching cloud requires only different connection-string
+values, not application code changes.
+
+All other cloud resource types are modelled per-cloud (separate `s3-*` / `abs-*` / `gcs-*`
+elements for object storage, `kms-*` / `keyvault-*` for key management,
+`sqs-*` / `servicebus-*` / `pubsub-*` for messaging, each tagged with its provider)
+because applications interacting with those resources do see cloud-specific differences:
+different SDK libraries, different authentication flows, different ENV variable shapes,
+and often different operational characteristics. The DB collapse only works because the
+cloud-specific surface area is fully hidden behind a connection string.
+
+When adding a new resource type to `cloud-resources.dsl`, the question to ask is: "Does
+the application code differ across clouds when consuming this resource?" If yes, model
+per-cloud with provider tags. If no (DB-style abstraction), collapse to one element.
+
+### Application-managed encryption — never modelled as cloud resource
+
+Some services use locally-managed symmetric keys (AES, etc.) stored as Kubernetes Secrets
+to encrypt data before persisting. Examples:
+
+- `kai-app-ai-chat`'s `TOKEN_ENCRYPTION_KEY` (32-byte AES-GCM, encrypts OAuth tokens before PostgreSQL)
+- `query-service`'s `QUERY_ENCRYPTION_AES_SECRET_KEY` (32-byte AES-256, encrypts workspace credentials)
+- Connection's `ENCRYPTION_KEYS__*` (Connection's own symmetric encryption infrastructure)
+
+These are NOT cloud KMS / Key Vault / Cloud KMS. The keys are random values stored as
+Kubernetes Secret resources with no involvement of any cloud provider's key-management
+service. Do NOT add `kms-key-*` or `keyvault-*` relationships for them. They are
+intentionally not modelled as cloud resources at all — the encryption is a service
+implementation detail invisible to other services.
+
+The only cloud KMS/Key Vault relationships modelled are those where the application
+explicitly calls a cloud KMS API at the application level — typically via
+`Keboola\ObjectEncryptor` or equivalents. Encryption-at-rest of databases or buckets
+(where the cloud provider transparently encrypts using a key the application never sees)
+is also NOT modelled — see "KMS / Key Vault — shared key vs service-owned keys" below.
+
+### Observability tooling — modelled at L1 platform level only, never per-component
+
+Datadog and LangSmith are observability platforms used across the Keboola platform. They
+are modelled as `Vendor`-tagged softwareSystems in `external-systems.dsl` with a single
+platform-level relationship (`keboolaPlatform -> datadog`, `keboolaPlatform -> langsmith`)
+that appears only on the L1 System Context view. They are NEVER modelled as per-service
+or per-component dependencies, even though most services emit telemetry to them.
+
+Signals to skip when scanning at component level:
+- All `DD_*` ENV keys (Datadog APM, logging, profiling) — appear in nearly every service's
+  infra_secrets and Helm secret templates
+- `LANGSMITH_API_KEY` / `LANGCHAIN_API_KEY` — currently only in the KAI apps (ai-chat,
+  kai-assistant, kai-agent), but treated identically
+
+Rationale: cross-cutting observability platforms are an architectural backdrop, not a
+service-level dependency. Showing them per-component would clutter every L3 diagram with
+the same edge. The L1 platform-level relationship captures the dependency once at the
+right level of abstraction.
+
+### Two distinct "job" concepts — do not confuse them
+
+Storage jobs (`Storage_Service_Jobs` in Connection): internal platform operations. NOT related to Queue.
+Component jobs (`Keboola\JobQueueClient\Client`): user pipeline runs owned by Queue service.
+
+### Two distinct "workspace" concepts — do not confuse them
+
+Connection workspaces: low-level DB schema in customer Snowflake/BigQuery. Managed by Connection.
+User-facing workspaces (SQL Editor sessions, Sandboxes, Data Apps): managed by Sandboxes or Editor.
+Both Editor and Sandboxes call Connection's workspace API for Snowflake/BigQuery backend provisioning.
+
+### KMS / Key Vault — shared key vs service-owned keys
+
+Shared job-runner key (`kms-key-job-runner-aws/azure/gcp`): signal is `var.job_runner_kms_key_id`.
+Service-owned keys: signal is a locally-created resource (e.g. `aws_kms_key.{service}.id`).
+KMS relationships are added only for application-level encryption, NOT DB encryption-at-rest.
+
+### Service-owned object storage vs shared buckets
+
+Only shared bucket is `s3-bucket-logs` (CFn: `kbc-logs-bucket`). All other buckets are service-owned.
+Signal: bucket variable references a locally-created resource, not a shared bucket variable.
+
+### Cross-service fan-out pattern — topic owner vs queue owner
+
+- **Connection** owns the SNS/EventGrid/Pub/Sub **topics** (`app-connection` Terraform module).
+  Topic ARNs are passed as output variables to subscriber modules.
+- **Subscriber services** (editor, vault, oauth, sandboxes-service) own their **subscription queues**,
+  provisioned in their own Terraform modules (typically `queue_connection.tf`), creating
+  `aws_sns_topic_subscription` pointing at `var.connection_events_topic_arn`.
+
+When scanning a subscriber, `var.connection_events_topic_arn` = subscribing to Connection's
+cross-service topic. Subscriber-owned queue (e.g. `sqs-queue-editor-service-connection-events`) is the
+C4 named resource. The Connection topic (`sns-topic-connection-events`) is already modelled.
+
+### Vendor-tagged elements and the L1 system context view
+
+Elements tagged `"Vendor"` (GitHub, SendGrid, Stripe, E2B, azure-marketplace, google-marketplace)
+represent third-party external SaaS services that are platform-level dependencies. They appear
+on the **L1 system context view** but are excluded from the L2 container view via
+`exclude "element.tag==Vendor"`. L3 component views that need to show Vendor elements must
+include them explicitly (e.g. `include github`, `include e2b`).
+
+**E2B** is the only Vendor-tagged element that originates from a component-level dependency
+(`kai-app-kai-agent` and `keboola-operator`) rather than a container-level one. It is explicitly
+included in both the L1 view and the relevant L3 views.
+
+**Google Vertex AI and Azure AI Foundry** are tagged `"CloudResource"`, not `"Vendor"`, because
+they are specific managed AI platform deployments within a cloud provider, not independent SaaS.
+
+### Elasticsearch — two separate instances
+
+Two independent Elasticsearch clusters are deployed via the single `apps/elasticsearch` Helm chart
+using an `elasticsearchInstances` values map:
+
+- `connection-elasticsearch` (namespace `connection-elasticsearch`): used by Connection for event
+  search, global search index, and audit log indexing. Currently on ES 9.x with upgrade tooling
+  (`remoteWhitelist`, `reindexRemoteCaCertSecret`) for zero-downtime version migration.
+- `job-queue-elasticsearch` (namespace `default`): used by Queue for job indexing and search.
+  Separate version, separate ECK configuration, separate infra secrets, snapshot-enabled.
+
+Both are modelled as standalone **containers** at L2 (not components), because they are
+independently deployed and shared across multiple components that are not co-located.
+etcd instances (`stream-etcd`, `templates-api-etcd`) are modelled as **components** because they
+are co-deployed as Bitnami Helm sub-charts within their parent service's Helm release and cannot
+be deployed independently.
+
+### Kubernetes clusters — modelled only for explicit application-level K8s API usage
+
+`aws-eks`, `azure-aks`, `gcp-gke` are defined in `external-systems.dsl` with tag
+`"CloudResource"`. They are NOT tagged `"CloudProvider"` or `"Vendor"`, because either
+of those tags would exclude them from L3 component views (which is precisely where
+they need to appear).
+
+**The implicit "runs on K8s" relationship is never modelled.** Every container in the
+platform runs on a managed K8s cluster, but this is not captured anywhere in the model
+— not at L1 (where `keboolaPlatform -> aws/azure/gcp` covers it transitively), not at
+L2, and not at L3. Modelling "runs on K8s" per-component would add the same edge to
+every diagram with no corresponding informational gain.
+
+**A `<component> -> aws-eks/azure-aks/gcp-gke` relationship is added only when the
+component calls the Kubernetes API at the application level** — meaning the K8s API is
+part of the component's actual work, not just its hosting environment. Concrete signals:
+
+- Spawning pods (e.g. job-queue-daemon spawning per-job runner pods)
+- Managing custom resources / CRDs (e.g. keboola-operator reconciling App CRDs)
+- Watching resources to drive runtime behaviour (e.g. apps-proxy watching App CRDs to route traffic)
+- Direct pod / service / PVC manipulation (e.g. sandboxes-component creating sandbox pods)
+
+Decision heuristic: would this component still need to function if you replaced K8s with
+a different orchestrator? If yes, no K8s relationship. If no (it's intrinsic to what the
+component does), add the relationship. `keboola-operator` runs in-cluster and might be
+tempting to treat as "just running on" K8s, but managing CRDs IS its purpose — so it
+gets the relationship.
+
+The model is the source of truth for which components are currently modelled this way —
+grep `aws-eks` / `azure-aks` / `gcp-gke` across `l3/*-external.dsl` to enumerate them. Do
+not maintain a list of these components in this file; it would inevitably drift from the
+model. When adding a new K8s relationship, also add a per-service note documenting the
+specific K8s usage pattern (the model edge description alone is too terse to convey
+*why* the component does this).
+
+---
+
+## Template for new entries
+
+## <repository-name>
+
+### <rule category>
+Description of non-obvious rules for scanning this service.

--- a/plugins/developer/skills/keboola-architecture/references/c4/views/views.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/views/views.dsl
@@ -1,0 +1,552 @@
+views {
+
+    # -------------------------------------------------------------------------
+    # L1 -- System Context
+    # -------------------------------------------------------------------------
+
+    systemContext keboolaPlatform "L1-SystemContext" "System context view of the Keboola platform and its satellite systems." {
+        include keboolaPlatform
+        include dataEngineer
+        include dataAnalyst
+        include developer
+        include endUser
+        include developerPortal
+        include telemetry
+        include aws
+        include azure
+        include gcp
+        include datadog
+        include github
+        include snowflake
+        include bigquery
+        include synapse
+        include exasol
+        include supabase
+        include sendgrid
+        include stripe
+        include azure-marketplace
+        include google-marketplace
+        include e2b
+        autoLayout
+    }
+
+    # -------------------------------------------------------------------------
+    # L2 -- Container views
+    # -------------------------------------------------------------------------
+
+    container keboolaPlatform "L2-KeboolaPlatform" "Container view of the Keboola Platform." {
+        include *
+        exclude "element.tag==Vendor"
+        exclude "element.tag==CloudResource"
+        autoLayout
+    }
+
+    container developerPortal "L2-DeveloperPortal" "Container view of the Developer Portal satellite system." {
+        include *
+        autoLayout
+    }
+
+    container telemetry "L2-Telemetry" "Container view of the Telemetry satellite system." {
+        include *
+        autoLayout
+    }
+
+    # -------------------------------------------------------------------------
+    # L2 -- Cloud Resources (per provider)
+    # -------------------------------------------------------------------------
+
+    container keboolaPlatform "L2-CloudResources-AWS" "AWS cloud resources used by the Keboola Platform." {
+        title "Container View: Keboola Platform - AWS Cloud Resources"
+        include *
+        exclude "element.tag==Azure"
+        exclude "element.tag==GCP"
+        exclude "element.tag==Vendor"
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    container keboolaPlatform "L2-CloudResources-Azure" "Azure cloud resources used by the Keboola Platform." {
+        title "Container View: Keboola Platform - Azure Cloud Resources"
+        include *
+        exclude "element.tag==AWS"
+        exclude "element.tag==GCP"
+        exclude "element.tag==Vendor"
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    container keboolaPlatform "L2-CloudResources-GCP" "GCP cloud resources used by the Keboola Platform." {
+        title "Container View: Keboola Platform - GCP Cloud Resources"
+        include *
+        exclude "element.tag==AWS"
+        exclude "element.tag==Azure"
+        exclude "element.tag==Vendor"
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    # -------------------------------------------------------------------------
+    # L3 -- Component views
+    # -------------------------------------------------------------------------
+
+    component ai "L3-AI" "Component view of the AI container." {
+        include *
+        include azure-openai-ai-service
+        include mysql-instance-job-queue
+        include kms-key-ai-aws
+        include kms-key-ai-azure
+        include kms-key-ai-gcp
+        include storage-ai-vectorstore-aws
+        include storage-ai-vectorstore-azure
+        include storage-ai-vectorstore-gcp
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component editor "L3-Editor" "Component view of the Editor container." {
+        include *
+        include mysql-instance-job-queue
+        include kms-key-editor-aws
+        include kms-key-editor-azure
+        include kms-key-editor-gcp
+        include sqs-queue-editor-service-sessions
+        include servicebus-queue-editor-service-sessions
+        include pubsub-topic-editor-service-sessions
+        include sqs-queue-editor-service-connection-events
+        include servicebus-queue-editor-service-connection-events
+        include pubsub-sub-editor-service-connection-events
+        include sqs-queue-editor-service-connection-audit-log
+        include servicebus-queue-editor-service-connection-audit-log
+        include pubsub-sub-editor-service-connection-audit-log
+        include sns-topic-connection-events
+        include eventgrid-topic-connection-events
+        include pubsub-topic-connection-events
+        include sns-topic-connection-audit-log
+        include eventgrid-topic-connection-audit-log
+        include pubsub-topic-connection-audit-log
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component sync-actions "L3-SyncActions" "Component view of the Sync Actions container." {
+        include *
+        include kms-key-job-runner-aws
+        include kms-key-job-runner-azure
+        include kms-key-job-runner-gcp
+        include s3-bucket-logs
+        include aws-eks
+        include azure-aks
+        include gcp-gke
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component scheduler "L3-Scheduler" "Component view of the Scheduler container." {
+        include *
+        include mysql-instance-job-queue
+        include kms-key-scheduler-aws
+        include kms-key-scheduler-azure
+        include kms-key-scheduler-gcp
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component queue "L3-Queue" "Component view of the Queue container (includes daemon group)." {
+        include *
+        include mysql-instance-job-queue
+        include kms-key-job-runner-aws
+        include kms-key-job-runner-azure
+        include kms-key-job-runner-gcp
+        include sqs-queue-daemon-jobs-to-start
+        include servicebus-queue-daemon-jobs-to-start
+        include pubsub-topic-daemon-jobs-to-start
+        include sqs-queue-daemon-flow-jobs-transition
+        include servicebus-queue-daemon-flow-jobs-transition
+        include pubsub-topic-daemon-flow-jobs-transition
+        include aws-eks
+        include azure-aks
+        include gcp-gke
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component encryption "L3-Encryption" "Component view of the Encryption container." {
+        include *
+        include kms-key-job-runner-aws
+        include kms-key-job-runner-azure
+        include kms-key-job-runner-gcp
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component omnisearch "L3-Omnisearch" "Component view of the Omnisearch container." {
+        include *
+        include azure-openai-ai-service
+        include storage-omnisearch-metastore-aws
+        include storage-omnisearch-metastore-azure
+        include storage-omnisearch-metastore-gcp
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component vault "L3-Vault" "Component view of the Vault container." {
+        include *
+        include mysql-instance-job-queue
+        include sqs-queue-vault-connection-events
+        include servicebus-queue-vault-connection-events
+        include pubsub-sub-vault-connection-events
+        include sns-topic-connection-events
+        include eventgrid-topic-connection-events
+        include pubsub-topic-connection-events
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component connection "L3-Connection" "Component view of the Connection container." {
+        include *
+        include mysql-instance-connection
+        include sqs-queue-connection-main
+        include servicebus-queue-connection-main
+        include pubsub-topic-connection-main
+        include sqs-queue-connection-commands
+        include servicebus-queue-connection-commands
+        include pubsub-topic-connection-commands
+        include sqs-queue-connection-events-elastic
+        include servicebus-queue-connection-events-elastic
+        include pubsub-sub-connection-events-elastic
+        include sqs-queue-connection-audit-log-events
+        include servicebus-queue-connection-audit-log-events
+        include pubsub-sub-connection-audit-log-events
+        include sqs-queue-connection-table-triggers
+        include servicebus-queue-connection-table-triggers
+        include pubsub-sub-connection-table-triggers
+        include sqs-queue-connection-search-index
+        include servicebus-queue-connection-search-index
+        include pubsub-sub-connection-search-index
+        include sns-topic-connection-events
+        include eventgrid-topic-connection-events
+        include pubsub-topic-connection-events
+        include sns-topic-connection-audit-log
+        include eventgrid-topic-connection-audit-log
+        include pubsub-topic-connection-audit-log
+        include sns-topic-connection-search-index
+        include eventgrid-topic-connection-search-index
+        include pubsub-topic-connection-search-index
+        include s3-bucket-logs
+        include sendgrid
+        include stripe
+        include snowflake
+        include bigquery
+        include aws-eks
+        include azure-aks
+        include gcp-gke
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component billing "L3-Billing" "Component view of the Billing container." {
+        include *
+        include mysql-instance-job-queue
+        include azure-marketplace
+        include google-marketplace
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component notification "L3-Notification" "Component view of the Notification container." {
+        include *
+        include mysql-instance-job-queue
+        include sqs-queue-notification-messages
+        include servicebus-queue-notification-messages
+        include pubsub-topic-notification-messages
+        include sendgrid
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component import "L3-Import" "Component view of the Import container." {
+        include *
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component oauth "L3-OAuth" "Component view of the OAuth container." {
+        include *
+        include mysql-instance-job-queue
+        include kms-key-oauth-aws
+        include kms-key-oauth-azure
+        include kms-key-oauth-gcp
+        include sqs-queue-oauth-connection-events
+        include servicebus-queue-oauth-connection-events
+        include pubsub-sub-oauth-connection-events
+        include sns-topic-connection-events
+        include eventgrid-topic-connection-events
+        include pubsub-topic-connection-events
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component mcp-server "L3-MCPServer" "Component view of the MCP Server container." {
+        include *
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component templates "L3-Templates" "Component view of the Templates container." {
+        include *
+        include github
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component kai-assistant "L3-KAIAssistant" "Component view of the KAI Assistant container." {
+        include *
+        include postgresql-instance
+        include s3-bucket-ai-chat-storage
+        include abs-ai-chat-storage
+        include gcs-ai-chat-storage
+        include kms-key-ai-chat-gcp
+        include google-vertex-ai
+        include azure-ai-foundry
+        include e2b
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component query "L3-Query" "Component view of the Query container." {
+        include *
+        include postgresql-instance
+        include snowflake
+        include bigquery
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component sandboxes "L3-Sandboxes" "Component view of the Sandboxes container." {
+        include *
+        include mysql-instance-job-queue
+        include kms-key-job-runner-aws
+        include kms-key-job-runner-azure
+        include kms-key-job-runner-gcp
+        include kms-key-sandboxes-service-aws
+        include kms-key-sandboxes-service-azure
+        include kms-key-sandboxes-service-gcp
+        include sqs-queue-sandboxes-service-connection-events
+        include servicebus-queue-sandboxes-service-connection-events
+        include pubsub-sub-sandboxes-service-connection-events
+        include sqs-queue-sandboxes-service-connection-audit-log
+        include servicebus-queue-sandboxes-service-connection-audit-log
+        include pubsub-sub-sandboxes-service-connection-audit-log
+        include sns-topic-connection-events
+        include eventgrid-topic-connection-events
+        include pubsub-topic-connection-events
+        include sns-topic-connection-audit-log
+        include eventgrid-topic-connection-audit-log
+        include pubsub-topic-connection-audit-log
+        include aws-eks
+        include azure-aks
+        include gcp-gke
+        include e2b
+        exclude "element.tag==CloudProvider"
+        autoLayout
+    }
+
+    component metastore "L3-Metastore" "Component view of the Metastore container." {
+        include *
+        include postgresql-instance
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    component git-service "L3-GitService" "Component view of the Git Service container." {
+        include *
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==CloudResource"
+        autoLayout
+    }
+
+    component api "L3-APIPortal" "Component view of the API Portal container." {
+        include *
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        exclude "element.tag==CloudResource"
+        autoLayout
+    }
+
+    component stream "L3-Stream" "Component view of the Stream container." {
+        include *
+        include kms-key-stream-aws
+        include kms-key-stream-azure
+        include kms-key-stream-gcp
+        include efs-stream-etcd-snapshots
+        include abs-stream-etcd-snapshots
+        include gcs-stream-etcd-snapshots
+        exclude "element.tag==CloudProvider"
+        exclude "element.tag==Vendor"
+        autoLayout
+    }
+
+    # -------------------------------------------------------------------------
+    # Styles
+    # -------------------------------------------------------------------------
+
+    styles {
+        # --- C4 base ---
+        element "Person" {
+            shape Person
+            background #1168bd
+            color #ffffff
+        }
+        element "Software System" {
+            background #1168bd
+            color #ffffff
+        }
+        element "Container" {
+            background #438dd5
+            color #ffffff
+        }
+        element "Component" {
+            background #85bbf0
+            color #000000
+        }
+
+        # --- Lifecycle (apply to own containers/components) ---
+        element "Legacy" {
+            background #cccccc
+            color #666666
+            border dashed
+        }
+        element "Uncommissioned" {
+            background #f5e6c8
+            color #8a6000
+            border dashed
+        }
+
+        # --- Infrastructure ---
+        element "SelfHosted" {
+            background #444444
+            color #ffffff
+        }
+
+        # --- External vendors ---
+        element "Vendor" {
+            background #1a5c33
+            color #ffffff
+        }
+
+        # --- Cloud resources: generic fallback (any CloudResource without a more specific type) ---
+        element "CloudResource" {
+            background #0d6e6e
+            color #ffffff
+        }
+
+        # ---------------------------------------------------------------------
+        # Cloud resources: BODY COLOR encodes resource TYPE.
+        # Order matters: more specific styles must come AFTER more general ones.
+        # ---------------------------------------------------------------------
+
+        # Database (slate blue)
+        element "MySQL" {
+            background #4a6fa5
+            color #ffffff
+        }
+        element "PostgreSQL" {
+            background #4a6fa5
+            color #ffffff
+        }
+
+        # Key management (brown)
+        element "KMS" {
+            background #6d4c41
+            color #ffffff
+        }
+        element "KeyVault" {
+            background #6d4c41
+            color #ffffff
+        }
+
+        # Topic / fan-out (rose). PubSub topics fall here; PubSub subscriptions
+        # carry an additional "Queue" tag and are recolored below.
+        element "SNS" {
+            background #b91c5c
+            color #ffffff
+        }
+        element "EventGrid" {
+            background #b91c5c
+            color #ffffff
+        }
+        element "PubSub" {
+            background #b91c5c
+            color #ffffff
+        }
+
+        # Queue / point-to-point (amber). Queue tag overrides PubSub for subscriptions.
+        element "SQS" {
+            background #d97706
+            color #ffffff
+        }
+        element "ServiceBus" {
+            background #d97706
+            color #ffffff
+        }
+        element "Queue" {
+            background #d97706
+            color #ffffff
+        }
+
+        # Object / file storage (forest green)
+        element "S3" {
+            background #2e7d32
+            color #ffffff
+        }
+        element "ABS" {
+            background #2e7d32
+            color #ffffff
+        }
+        element "GCS" {
+            background #2e7d32
+            color #ffffff
+        }
+        element "EFS" {
+            background #2e7d32
+            color #ffffff
+        }
+
+        # AI services (purple). Tag added to OpenAI, Vertex AI, AI Foundry.
+        element "AI" {
+            background #6a1b9a
+            color #ffffff
+        }
+
+        # ---------------------------------------------------------------------
+        # Cloud resources: BORDER COLOR encodes PROVIDER.
+        # Stroke + strokeWidth do not collide with background, so type+provider
+        # styles merge naturally on elements tagged with both.
+        # ---------------------------------------------------------------------
+
+        element "AWS" {
+            stroke #ff9900
+            strokeWidth 4
+        }
+        element "Azure" {
+            stroke #0078d4
+            strokeWidth 4
+        }
+        element "GCP" {
+            stroke #ea4335
+            strokeWidth 4
+        }
+    }
+
+}

--- a/plugins/developer/skills/keboola-architecture/references/c4/workspace.dsl
+++ b/plugins/developer/skills/keboola-architecture/references/c4/workspace.dsl
@@ -1,0 +1,6 @@
+workspace "Keboola Connection" "C4 architecture model of the Keboola platform" {
+
+    !include model/model.dsl
+    !include views/views.dsl
+
+}

--- a/plugins/developer/skills/keboola-architecture/scripts/sync.sh
+++ b/plugins/developer/skills/keboola-architecture/scripts/sync.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Refreshes the bundled C4 snapshot from keboola/platform-architecture-and-concepts.
+#
+# Requires:
+#   - gh CLI authenticated with access to the private repo
+#   - rsync, tar
+#
+# Run from anywhere; the script resolves its own location.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+REFERENCES_DIR="$SKILL_DIR/references"
+
+REPO="keboola/platform-architecture-and-concepts"
+REF="${1:-main}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "error: gh CLI is required" >&2
+    exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "error: gh is not authenticated (run 'gh auth login')" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "Fetching ${REPO}@${REF} ..."
+gh api "repos/${REPO}/tarball/${REF}" > "$tmp_dir/repo.tar.gz"
+
+echo "Extracting ..."
+tar -xzf "$tmp_dir/repo.tar.gz" -C "$tmp_dir"
+extracted_root="$(/usr/bin/find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d ! -name 'repo*')"
+
+if [[ ! -d "$extracted_root/c4" ]]; then
+    echo "error: extracted archive does not contain c4/ at top level" >&2
+    exit 1
+fi
+
+echo "Updating references/ ..."
+rm -rf "$REFERENCES_DIR/c4" "$REFERENCES_DIR/c4-docs"
+mkdir -p "$REFERENCES_DIR/c4-docs"
+
+rsync -a \
+    --exclude='skills/' \
+    --exclude='*.tmp' \
+    --exclude='*.tmp.*' \
+    --exclude='*.deleted' \
+    --exclude='*.html' \
+    --exclude='*.png' \
+    --exclude='workspace.json' \
+    "$extracted_root/c4/" "$REFERENCES_DIR/c4/"
+
+cp "$extracted_root/c4-docs/c4-approach.md" "$REFERENCES_DIR/c4-docs/c4-approach.md"
+
+file_count="$(/usr/bin/find "$REFERENCES_DIR" -type f | wc -l | tr -d ' ')"
+size="$(du -sh "$REFERENCES_DIR" | cut -f1)"
+
+echo "Done. ${file_count} files, ${size}."
+echo "Review with: git diff -- $REFERENCES_DIR"


### PR DESCRIPTION
<img width="1822" height="1185" alt="image" src="https://github.com/user-attachments/assets/472d49d8-6bc7-4a80-877b-78054faad2d9" />


## Summary

Adds a new `keboola-architecture` skill to the developer plugin. It bundles a point-in-time snapshot of the Keboola platform's C4 architecture model so any agent can answer impact-analysis and dependency questions without scanning every service's source.

**Source:** `keboola/platform-architecture-and-concepts` — folders `c4/` and `c4-docs/c4-approach.md` only. Other folders in that repo (`apis/`, `clients/`, `concepts/`, `services/`) are obsolete and are explicitly excluded.

## What's in the skill

- `SKILL.md` — when to use (impact analysis, dependency questions, onboarding), file-map (question → which file to read), and caveats (idealized model, one-directional scanning).
- `references/c4/` — full Structurizr DSL: `workspace.dsl`, `model/`, `l2/containers.dsl`, per-service `l3/*.dsl` (inter-service + cloud-vendor edges) + `l3/*.md` findings reports, `service-knowledge.md`, `list of services.md`, `views/`.
- `references/c4-docs/c4-approach.md` — methodology and design decisions.
- `scripts/sync.sh` — refreshes the snapshot from upstream via `gh` (requires `gh` auth with access to the private repo).

Bundle size: 81 files, ~496 KB. Lazy-loaded — SKILL.md is ~600 words; the references load only when Claude needs them.

## Why a snapshot, not a live fetch

PoC priorities: zero runtime dependency on `gh` auth, offline-friendly, deterministic. Drift is managed by re-running `scripts/sync.sh` before answering edge cases or when the architecture has visibly changed. Long-term we can move to a live MCP server.

## Versioning

- `plugins/developer` plugin: 1.7.1 → **1.8.0** (additive — new skill)
- Marketplace entry updated to match.
- `plugins/developer/README.md` gets a new "Skills" section.
- Root `README.md` features list updated.

## Companion PR

Upstream guardrails (AGENTS.md + DeepWiki config marking the obsolete folders) are added in [keboola/platform-architecture-and-concepts#7](https://github.com/keboola/platform-architecture-and-concepts/pull/7).

## Test plan

- [x] `claude plugin validate .` passes (verified locally)
- [x] In a Claude Code session with the developer plugin enabled, ask: *"What does the Queue service depend on?"* — confirm the agent reads `references/c4/l3/job-queue.dsl` rather than guessing or hitting the obsolete folders.
- [ ] Run `scripts/sync.sh` and verify it overwrites `references/` cleanly without modifying anything else.