### PR TITLE
docs: add Skills workflow guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,13 @@ When adding new commands, agents, or skills to a plugin:
 3. Bump the version in `.claude-plugin/marketplace.json` for the corresponding plugin entry
 4. Update the root README.md feature list for the affected plugin (add/remove items from the list)
 
-## Skill Script Path Conventions
+## Skills
+
+### Skills Workflow
+
+- When creating or modifying skills in the AI kit, remember publishing requires a version bump in the skill manifest. Don't rename skills without explicit user approval.
+
+### Script Path Conventions
 
 - Scripts must detect their own location using `SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"` and derive `SKILL_DIR="$(dirname "$SCRIPT_DIR")"`
 - Scripts run from the user's **project root**, never from the skill directory


### PR DESCRIPTION
## Release Notes

Documentation-only change. No runtime impact.

## Plans for customer communication
None.

## Impact analysis

Updates the repo-level `CLAUDE.md` so future Claude Code sessions know the AI kit's skill publishing rules:

- Publishing a skill change requires a version bump in the skill manifest.
- Skills must not be renamed without explicit user approval.

Existing `Skill Script Path Conventions` content is preserved verbatim, now nested as `### Script Path Conventions` under a unified `## Skills` parent. No behavior change for any plugin or skill.

## Change type

Docs.

## Justification

Codifies feedback that has been recurring in sessions — keeps the rule discoverable next time someone (or Claude) touches a skill.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.