### PR TITLE
Add keboola-git plugin (managed Forgejo access + copy command)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,13 @@
       "category": "operations"
     },
     {
+      "name": "keboola-git",
+      "description": "Access Keboola-managed Git (Forgejo) repos for python-js data apps via the kbagent CLI — provision repos, mint push credentials, and copy source between GitHub and Keboola git with the 15MB/build-at-deploy path handled",
+      "version": "1.0.0",
+      "source": "./plugins/keboola-git",
+      "category": "development"
+    },
+    {
       "name": "powerbi-to-sl",
       "description": "Migrate an existing Microsoft Power BI semantic model (TMDL or per-table JSON) into a Keboola semantic layer model. Brownfield companion to sl-toolkit.",
       "version": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ claude-kit/
 │   ├── component-developer/ # Keboola Python component development
 │   ├── dataapp-developer/   # Data app development & deployment for Keboola
 │   ├── keboola-cli/         # Keboola project management and review
+│   ├── keboola-git/         # Keboola-managed Git (Forgejo) access for data apps
 │   ├── powerbi-to-sl/       # Migrate Power BI semantic models to Keboola
 │   └── sl-toolkit/          # Semantic layer inspect, validate, build + conversational CRUD
 ├── README.md                # This file
@@ -84,6 +85,21 @@ A project management and review toolkit for Keboola projects. Includes CLI sync 
 - 🔒 **Security Audit**: Credential scanning, PII detection, GDPR/CCPA compliance checks
 
 **[→ View Keboola CLI Plugin Documentation](./plugins/keboola-cli/README.md)**
+
+### Keboola Git Plugin
+
+**Location**: [`./plugins/keboola-git`](./plugins/keboola-git)
+
+Access Keboola-managed Git (Forgejo) repos for python-js data apps via the `kbagent` CLI — provision repos, mint push credentials, push source with raw git, and deploy, including the ~15MB / HTTP 413 build-at-deploy path.
+
+**Features:**
+- 🎯 **Skill**: `keboola-git` — provision/find the managed repo, mint a one-time `git_clone_url`, raw clone/push, 413 + build-at-deploy recipe, deploy + verify
+- ⚡ **Command**: `/keboola-git-copy to-keboola|to-github` — bidirectional GitHub ↔ Keboola git source copy with size guard and scratch-branch safety
+- 📦 **Build-at-deploy**: untrack committed builds (`frontend/.next`), build in `keboola-config/setup.sh` to stay under the 15MB push cap
+- 🔒 **Credential safety**: one-time push secrets kept in shell vars, never committed; no force-push, scratch-branch-only reverse copies
+- 🛠️ **kbagent-CLI driven**: ships no MCP server
+
+**[→ View Keboola Git Plugin Documentation](./plugins/keboola-git/README.md)**
 
 ### sl-toolkit Plugin
 

--- a/plugins/keboola-git/.claude-plugin/plugin.json
+++ b/plugins/keboola-git/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "keboola-git",
+  "version": "1.0.0",
+  "description": "Access Keboola-managed Git (Forgejo) repos for python-js data apps via the kbagent CLI — provision repos, mint push credentials, and copy source between GitHub and Keboola git with the 15MB/build-at-deploy path handled",
+  "author": {
+    "name": "Keboola :(){:|:&};: s.r.o.",
+    "email": "support@keboola.com"
+  },
+  "keywords": [
+    "keboola",
+    "kbagent",
+    "managed-git",
+    "forgejo",
+    "data-app",
+    "git",
+    "build-at-deploy",
+    "deploy",
+    "python-js"
+  ]
+}

--- a/plugins/keboola-git/README.md
+++ b/plugins/keboola-git/README.md
@@ -1,0 +1,52 @@
+# Keboola Git Plugin
+
+Access **Keboola-managed Git (Forgejo)** repos for python-js data apps through the
+`kbagent` CLI. Keboola data apps can host their source in a Keboola-managed repo instead of
+GitHub; this plugin gives Claude Code the context to provision those repos, mint push
+credentials, push source in with raw `git`, and deploy — including the non-obvious
+**~15MB / HTTP 413** push cap that forces a **build-at-deploy** approach for repos that
+commit their build.
+
+## 🎯 Available Skill
+
+### `keboola-git`
+**Activation**: Automatic when working with a Keboola-managed git repo for a data app — provisioning, finding `repo_url`, minting a `git_clone_url`, pushing source, handling HTTP 413, or deploying from the managed repo.
+
+Covers:
+- Provision a managed repo via `modify_python_js_data_app`; find existing ones via `get_data_apps`.
+- Mint a one-time push credential with `create_python_js_data_app_git_credential` (`git_clone_url` = `https://kai:<secret>@git.<stack>/keboola/app-<id>.git`).
+- Raw `git clone` / `remote add` / `push keboola HEAD:main` (kbagent has no repo-copy helper).
+- The **15MB / HTTP 413 cap** and the **build-at-deploy** recipe (untrack `frontend/.next`, build in `keboola-config/setup.sh`).
+- Deploy + verify: `deploy_data_app`, logs, password, `POST /` probe.
+- A full command catalog and gotchas table in [`skills/keboola-git/references/managed-git.md`](./skills/keboola-git/references/managed-git.md).
+
+## ⚡ Command
+
+### `/keboola-git-copy`
+Bidirectional copy of a data app's source between GitHub and Keboola git.
+
+```
+/keboola-git-copy to-keboola|to-github --source <repo-url-or-path> --branch <branch> --project <alias> [--config <cfg>] [--app-name <name>]
+```
+
+- **`to-keboola`** (GitHub → Keboola): resolve/provision the app, mint a credential, clone the source, run the size guard, apply build-at-deploy if a build is committed, push to `main`, then offer to deploy and verify.
+- **`to-github`** (Keboola → GitHub): clone the managed `main` and push to a **user-owned scratch/feature branch only** — confirms before any shared-repo push, never force-pushes.
+
+## ✅ Prerequisites
+
+- **kbagent** installed and on `PATH` (`kbagent --version`). See the `keboola-cli` plugin / kbagent docs.
+- Project registered: `kbagent --json project add --project <alias> --stack <stack-url> --storage-token "$KBC_TOKEN"`.
+- `export KBAGENT_CONVERSATION_ID=$(uuidgen)` once per shell session.
+- A **manage token** in the environment for `data-app logs` / `password` / `delete` (used with `--allow-env-manage-token`).
+- This plugin is **kbagent-CLI driven** — it ships **no MCP server**.
+
+## 🔒 Safety
+
+- `git_clone_url` credentials are one-time secrets: held in a shell variable only, never committed or logged; rotate (re-mint) if exposed.
+- Never force-push; the Forgejo pre-receive hook declines branch deletes.
+- Reverse copies default to a user-owned scratch repo + feature branch; shared-repo pushes require confirmation.
+
+## Related
+
+- [`dataapp-developer`](../dataapp-developer) — `dataapp-deployment` skill for `keboola-config/` (setup.sh, nginx, supervisord) and `dataapp-dev` for Streamlit.
+- [`keboola-cli`](../keboola-cli) — broader kbagent project management and review.

--- a/plugins/keboola-git/README.md
+++ b/plugins/keboola-git/README.md
@@ -17,7 +17,7 @@ Covers:
 - Mint a one-time push credential with `create_python_js_data_app_git_credential` (`git_clone_url` = `https://kai:<secret>@git.<stack>/keboola/app-<id>.git`).
 - Raw `git clone` / `remote add` / `push keboola HEAD:main` (kbagent has no repo-copy helper).
 - The **15MB / HTTP 413 cap** and the **build-at-deploy** recipe (untrack `frontend/.next`, build in `keboola-config/setup.sh`).
-- Deploy + verify: `deploy_data_app`, logs, password, `POST /` probe.
+- Deploy + verify from the logs (`Compiled successfully`, `Completed: setup_sh`, `node-frontend entered RUNNING`) — not an HTTP probe, since `GET /` hits the platform login gate and `POST /` is an nginx health rule.
 - A full command catalog and gotchas table in [`skills/keboola-git/references/managed-git.md`](./skills/keboola-git/references/managed-git.md).
 
 ## ⚡ Command

--- a/plugins/keboola-git/commands/keboola-git-copy.md
+++ b/plugins/keboola-git/commands/keboola-git-copy.md
@@ -1,0 +1,68 @@
+---
+name: keboola-git-copy
+description: Copy a data app's source between GitHub and Keboola-managed Git (Forgejo) in either direction, handling the ~15MB/HTTP 413 push cap via build-at-deploy.
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+argument-hint: "to-keboola|to-github --source <repo-url-or-path> --branch <branch> --project <alias> [--config <cfg>] [--app-name <name>]"
+---
+
+# Copy a Data App Repo: GitHub ↔ Keboola Git
+
+Bidirectional copy of a python-js data app's source between GitHub and a Keboola-managed
+Forgejo repo. **First, use the `keboola-git` skill** for the full kbagent command catalog,
+credential handling, and the 413 / build-at-deploy recipe — this command is the procedure
+that drives it.
+
+## Arguments
+
+- **direction** (positional): `to-keboola` (GitHub → Keboola) or `to-github` (Keboola → GitHub).
+- `--source` — source repo URL or local path (for `to-keboola`), or the GitHub scratch repo URL (for `to-github`).
+- `--branch` — source branch to clone (`to-keboola`) or destination scratch/feature branch (`to-github`).
+- `--project` — kbagent project alias.
+- `--config` — `configuration_id` of an existing app (optional; provision a new one if absent).
+- `--app-name` — display name when provisioning a new app (`to-keboola` only).
+
+## Setup (both directions)
+
+1. Ensure prerequisites: `kbagent --version`, project registered, `export KBAGENT_CONVERSATION_ID=$(uuidgen)`.
+2. Do all git work under `./.keboola-git-work/` in the user's CWD; ensure `.keboola-git-work/` is gitignored.
+3. Always pass `--json` to kbagent `tool call`. Keep any `git_clone_url` in a shell variable only — never commit or log it.
+
+---
+
+## `to-keboola` (GitHub → Keboola)
+
+1. **Resolve or provision the app.**
+   - If `--config` given: confirm with `get_data_apps` and read its `data_app_id` / `repo_url`.
+   - Else: provision with `modify_python_js_data_app` (use `--app-name`); capture `configuration_id`, `data_app_id`, `repo_url`.
+2. **Mint a push credential** with `create_python_js_data_app_git_credential` → `git_clone_url` into `$URL`.
+3. **Clone the source** (single-branch) into `./.keboola-git-work/app`.
+4. **Size guard:** `find . -size +15M -not -path '*/.git/*'`.
+   - If a committed build is found (e.g. `frontend/.next`), apply **source-only + build-at-deploy**:
+     untrack + gitignore the build dir and `node_modules/`; set `keboola-config/setup.sh` to
+     `npm ci && npm run build` and copy `frontend/.next/static` + `frontend/public` into the
+     `.next/standalone/` tree. Commit the source-only tree. (See the `dataapp-developer:dataapp-deployment` skill for setup.sh wiring.)
+   - Re-run the guard; it must return nothing.
+5. **Push:** `git remote add keboola "$URL" && git push keboola HEAD:main`.
+   - On `HTTP 413`, re-run the size guard and **report the offending file** — it can't be split; ask the user how to externalize it.
+6. **Offer to deploy + verify:** `deploy_data_app`, tail logs (~90s build), get password, probe `POST /` for 200.
+
+## `to-github` (Keboola → GitHub)
+
+1. **Resolve the managed repo:** `get_data_apps` (or use `--config`) → `repo_url`, `data_app_id`.
+2. **Mint a credential** → `$URL`; **clone** managed `main` into `./.keboola-git-work/app`.
+3. **Add the GitHub remote:** `git remote add github <--source scratch repo url>`.
+4. **Push to the user-specified scratch/feature branch only:**
+   `git push github main:<--branch>`.
+   - **Confirm before any push to a shared repo or default branch.** Never force-push.
+
+---
+
+## Guardrails
+
+- Never write to a shared/production GitHub repo without explicit confirmation; default to a user-owned scratch repo + feature branch.
+- Never force-push; the Forgejo pre-receive hook also declines branch deletes.
+- Treat any `git_clone_url` / credential as a one-time secret: shell var only, rotate if exposed.
+- Backend *data* errors after a successful deploy (missing Storage tables) are expected in empty projects and are not copy/deploy failures.

--- a/plugins/keboola-git/commands/keboola-git-copy.md
+++ b/plugins/keboola-git/commands/keboola-git-copy.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash
   - Read
   - Edit
+  - Write
 argument-hint: "to-keboola|to-github --source <repo-url-or-path> --branch <branch> --project <alias> [--config <cfg>] [--app-name <name>]"
 ---
 
@@ -39,15 +40,20 @@ that drives it.
    - Else: provision with `modify_python_js_data_app` (use `--app-name`); capture `configuration_id`, `data_app_id`, `repo_url`.
 2. **Mint a push credential** with `create_python_js_data_app_git_credential` → `git_clone_url` into `$URL`.
 3. **Clone the source** (single-branch) into `./.keboola-git-work/app`.
-4. **Size guard:** `find . -size +15M -not -path '*/.git/*'`.
+4. **Size guard (working tree):** `find . -size +15M -not -path '*/.git/*'`.
    - If a committed build is found (e.g. `frontend/.next`), apply **source-only + build-at-deploy**:
      untrack + gitignore the build dir and `node_modules/`; set `keboola-config/setup.sh` to
-     `npm ci && npm run build` and copy `frontend/.next/static` + `frontend/public` into the
-     `.next/standalone/` tree. Commit the source-only tree. (See the `dataapp-developer:dataapp-deployment` skill for setup.sh wiring.)
-   - Re-run the guard; it must return nothing.
-5. **Push:** `git remote add keboola "$URL" && git push keboola HEAD:main`.
-   - On `HTTP 413`, re-run the size guard and **report the offending file** — it can't be split; ask the user how to externalize it.
-6. **Offer to deploy + verify:** `deploy_data_app`, tail logs (~90s build), get password, probe `POST /` for 200.
+     `cd frontend && npm ci && npm run build`, then copy `static` + `public` to wherever the build
+     put `server.js` (`find .next/standalone -name server.js` — single-package vs monorepo differ).
+     Commit the source-only tree. (See the `dataapp-developer:dataapp-deployment` skill for setup.sh wiring.)
+   - Re-run the working-tree guard; it must return nothing.
+5. **History guard (CRITICAL):** a build committed in an earlier commit still 413s — `git push`
+   sends all reachable history, the `find` guard only sees the working tree. Check:
+   `git rev-list --objects HEAD | git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' | awk '$1=="blob" && $2>15000000'`.
+   If non-empty: push an `--orphan` clean commit (fresh managed repo) or `git filter-repo`/BFG (preserve history).
+6. **Push:** `git remote add keboola "$URL" && git push keboola HEAD:main` (or `clean-main:main` if you orphaned).
+   - On `HTTP 413`, re-run **both** guards and **report the offending file** — it can't be split; ask the user how to externalize it.
+7. **Offer to deploy + verify:** `deploy_data_app`, tail logs (~90s build), get password, probe `POST /` for 200.
 
 ## `to-github` (Keboola → GitHub)
 

--- a/plugins/keboola-git/commands/keboola-git-copy.md
+++ b/plugins/keboola-git/commands/keboola-git-copy.md
@@ -53,7 +53,11 @@ that drives it.
    If non-empty: push an `--orphan` clean commit (fresh managed repo) or `git filter-repo`/BFG (preserve history).
 6. **Push:** `git remote add keboola "$URL" && git push keboola HEAD:main` (or `clean-main:main` if you orphaned).
    - On `HTTP 413`, re-run **both** guards and **report the offending file** — it can't be split; ask the user how to externalize it.
-7. **Offer to deploy + verify:** `deploy_data_app`, tail logs (~90s build), get password, probe `POST /` for 200.
+7. **Offer to deploy + verify:** `deploy_data_app`, then tail logs (`setup_sh` ~2min) and confirm
+   from the logs — `✓ Compiled successfully`, `Completed: setup_sh` (static `cp` worked), and
+   `success: node-frontend entered RUNNING` + `Ready in`. Don't trust an HTTP probe: unauthenticated
+   `GET /` returns the platform login gate (200), and `POST /` 200 is just the nginx health rule.
+   A `python-api` crash loop on a Storage `404` is an expected data error in an empty project, not a deploy failure.
 
 ## `to-github` (Keboola → GitHub)
 

--- a/plugins/keboola-git/skills/keboola-git/SKILL.md
+++ b/plugins/keboola-git/skills/keboola-git/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: keboola-git
+description: Use when accessing a Keboola-managed Git (Forgejo) repo for a python-js data app via the kbagent CLI — provisioning the repo, finding its repo_url, minting a git_clone_url / push credential with create_python_js_data_app_git_credential, pushing source to Keboola git, copying source between GitHub and Keboola git, working around the ~15MB / HTTP 413 push cap with build-at-deploy, or deploying a data app from its managed git repo. Triggers: kbagent, Keboola managed git, Forgejo, data app repo, repo_url, git_clone_url, create git credential, push to Keboola git, build-at-deploy, HTTP 413, deploy from git.
+allowed-tools: ['*']
+---
+
+# Keboola-Managed Git (Forgejo) for Data Apps
+
+Keboola python-js data apps can host their source in a **Keboola-managed Git repo (Forgejo)** instead of GitHub. This skill gives you the context to access those repos through the `kbagent` CLI: provision a repo, mint a push credential, push source in with raw `git`, and deploy. kbagent has **no repo-copy helper** — you drive `git clone` / `git remote add` / `git push` yourself.
+
+## What this does / when not
+
+**Use this for:** reading or writing a managed Forgejo repo for a python-js data app; moving an app's source between GitHub and Keboola git; pushing source and deploying from the managed repo.
+
+**Not for:** authoring the contents of `keboola-config/` (nginx, supervisord, setup.sh) — that's the `dataapp-developer:dataapp-deployment` skill. Not for Streamlit app development — that's `dataapp-developer:dataapp-dev`. This skill assumes the app source already exists somewhere; it handles the *git plumbing* to get it into Keboola and deployed.
+
+## Working Directory Context
+
+All `git` and `kbagent` operations run from the **user's project root** or a **scratch clone created under the user's CWD** — never from this skill/plugin directory.
+
+- Do clone/copy work in `./.keboola-git-work/<app>/` under the user's CWD. Add `.keboola-git-work/` to the project `.gitignore` so the scratch clone is never committed.
+- Before any in-place git operation on an existing repo, validate it's a worktree: `git rev-parse --is-inside-work-tree`.
+- Never run git commands against the plugin install directory.
+
+## Prerequisites
+
+1. **kbagent installed** and on `PATH` (`kbagent --version`). Install: see the kbagent docs / `kbagent:kbagent` skill.
+2. **Project registered** with kbagent (one-time per project):
+   ```bash
+   kbagent --json project add --project <alias> --stack <stack-url> --storage-token "$KBC_TOKEN"
+   ```
+3. **Conversation id** exported once per shell session:
+   ```bash
+   export KBAGENT_CONVERSATION_ID=$(uuidgen)
+   ```
+4. **Always pass `--json`** to tool calls so you can parse `configuration_id`, `repo_url`, `git_clone_url` reliably.
+
+## 1. Access the managed repo
+
+**Existing app** — find its repo and config:
+```bash
+kbagent --json tool call get_data_apps --project <alias> --input '{}'
+```
+Note the `configuration_id`, `data_app_id`, and `repo_url`
+(`https://git.<stack>/keboola/app-<data_app_id>.git`).
+
+**Provision a new app + repo:**
+```bash
+kbagent --json tool call modify_python_js_data_app --project <alias> \
+  --input '{"name":"<Display Name>","slug":"<slug>","description":"<desc>"}'
+```
+Returns `configuration_id`, `data_app_id`, `repo_url`. Two-app model: the **prod** config owns the only repo; draft branches advance from it.
+
+## 2. Mint a push credential (one-time secret)
+
+```bash
+kbagent --json tool call create_python_js_data_app_git_credential --project <alias> \
+  --input '{"configuration_id":"<cfg>"}'
+```
+Returns `git_clone_url` = `https://kai:<secret>@git.<stack>/keboola/app-<data_app_id>.git`.
+
+- The secret is **shown once**. Mint a fresh one anytime — they're cheap and revocable-by-rotation.
+- **Keep it in a shell variable only.** Never commit it, never `echo` it into a file, never paste it into a log or message. Read it into a var and reference `"$URL"`:
+  ```bash
+  URL='https://kai:<secret>@git.<stack>/keboola/app-<id>.git'
+  ```
+
+## 3. Clone / push pattern (raw git)
+
+```bash
+mkdir -p ./.keboola-git-work && cd ./.keboola-git-work
+git clone --single-branch --branch <branch> <source-repo> app && cd app
+git remote add keboola "$URL"
+git push keboola HEAD:main
+```
+- The pre-receive hook **declines branch deletes** — pushing new commits to `main` or a draft branch advances normally, but you cannot delete a remote branch.
+- Never force-push a shared/managed branch.
+
+## 4. The 15MB / HTTP 413 cap + build-at-deploy (CRITICAL)
+
+Forgejo rejects pushes over **~15MB** with **HTTP 413**. A single file over the limit cannot be split — you must not track it.
+
+**Push source only.** Repos that commit their build (e.g. `frontend/.next` ~55MB, often including a 15.3MB macOS `sharp` binary that's also the *wrong* binary for the Linux runtime) must move the build into deploy time:
+
+1. Size guard before pushing:
+   ```bash
+   find . -size +15M -not -path '*/.git/*'
+   ```
+2. If a build dir is tracked, stop tracking it and gitignore it:
+   ```bash
+   git rm -r --cached frontend/.next
+   printf '%s\n' 'frontend/.next/' 'node_modules/' >> .gitignore
+   ```
+3. Move the build into `keboola-config/setup.sh` so it runs in the Linux container at deploy:
+   ```bash
+   # in keboola-config/setup.sh, in the app dir:
+   npm ci && npm run build
+   # Next.js standalone needs static assets copied alongside the server:
+   cp -r frontend/.next/static frontend/.next/standalone/frontend/.next/static
+   cp -r frontend/public      frontend/.next/standalone/frontend/public
+   ```
+   For the exact setup.sh / nginx / supervisord wiring, cross-reference the **`dataapp-developer:dataapp-deployment`** skill.
+4. Commit the source-only tree, re-run the size guard (no tracked file >15MB), then push.
+
+If a push still 413s, re-run the size guard and **report the offending file** — the user must decide how to externalize it (it can't be split).
+
+## 5. Deploy + verify
+
+```bash
+kbagent --json tool call deploy_data_app --project <alias> \
+  --input '{"action":"deploy","configuration_id":"<cfg>"}'
+```
+Watch the build (~90s for `npm ci` + `next build`):
+```bash
+kbagent --allow-env-manage-token data-app logs --project <alias> --app-id <data_app_id> --lines 200
+```
+Get the app password and probe the frontend:
+```bash
+kbagent --json --allow-env-manage-token data-app password --project <alias> --app-id <data_app_id>
+# A 200 from POST / means the frontend is serving (the platform POSTs / on startup)
+```
+Set env/secrets and redeploy if needed:
+```bash
+kbagent --allow-env-manage-token data-app secrets-set --project <alias> --app-id <data_app_id> '#KEY=VAL'
+```
+
+**Success = repo in Keboola git + app deploys + container builds + frontend serves + backend process starts.** Backend *data* errors (missing Storage tables) mean the app is running and looking for data — not a git/deploy failure.
+
+## Gotchas
+
+Full command catalog, the 413/build-at-deploy recipe, and the gotchas table live in
+[`references/managed-git.md`](references/managed-git.md).

--- a/plugins/keboola-git/skills/keboola-git/SKILL.md
+++ b/plugins/keboola-git/skills/keboola-git/SKILL.md
@@ -136,21 +136,32 @@ offending file** — the user must decide how to externalize it (it can't be spl
 kbagent --json tool call deploy_data_app --project <alias> \
   --input '{"action":"deploy","configuration_id":"<cfg>"}'
 ```
-Watch the build (~90s for `npm ci` + `next build`):
+**Verify from the logs — they are the authoritative signal** (build is ~90s+ for `npm ci` + `next build`; `setup_sh` can take ~2min total):
 ```bash
-kbagent --allow-env-manage-token data-app logs --project <alias> --app-id <data_app_id> --lines 200
+kbagent --allow-env-manage-token data-app logs --project <alias> --app-id <data_app_id> --lines 300
 ```
-Get the app password and probe the frontend:
+Look for, in order: `✓ Compiled successfully` and `Generating static pages` (the `next build`
+finished), `Completed: setup_sh` (the static-asset `cp` succeeded — under `set -e` a wrong
+copy path would abort here), then `success: node-frontend entered RUNNING state` and
+`✓ Ready in …ms` (the standalone server is up on :3000). The python service shows
+`success: python-api entered RUNNING state`. If a deeper window is dominated by one service's
+restart loop, raise `--lines` to see the other service's earlier startup.
+
+**Do NOT rely on an HTTP probe to confirm the frontend.** An unauthenticated `GET /` returns
+the **Keboola platform login gate** (HTTP 200, `<title>Login</title>`, no `_next/static`
+references) — that's the platform auth proxy *in front of* the container, not your app. And
+`POST /` returns 200 from the nginx `location = /` health rule regardless of app state. Real
+proof that the built frontend serves is `node-frontend entered RUNNING` + `Ready in` in the
+logs (optionally: authenticate with the app password, then check the HTML references
+`/_next/static/…`).
+
+Get the app password / set secrets + redeploy as needed:
 ```bash
 kbagent --json --allow-env-manage-token data-app password --project <alias> --app-id <data_app_id>
-# A 200 from POST / means the frontend is serving (the platform POSTs / on startup)
-```
-Set env/secrets and redeploy if needed:
-```bash
 kbagent --allow-env-manage-token data-app secrets-set --project <alias> --app-id <data_app_id> '#KEY=VAL'
 ```
 
-**Success = repo in Keboola git + app deploys + container builds + frontend serves + backend process starts.** Backend *data* errors (missing Storage tables) mean the app is running and looking for data — not a git/deploy failure.
+**Success = repo in Keboola git + app deploys + container builds + `node-frontend` RUNNING + backend process starts.** Backend *data* errors — e.g. `python-api` crash-looping on a Storage `404 Not Found` from its startup data load — mean the app is running and looking for tables that don't exist in an empty project. That's a data condition, **not** a git/deploy failure.
 
 ## Gotchas
 

--- a/plugins/keboola-git/skills/keboola-git/SKILL.md
+++ b/plugins/keboola-git/skills/keboola-git/SKILL.md
@@ -93,16 +93,42 @@ Forgejo rejects pushes over **~15MB** with **HTTP 413**. A single file over the 
    ```
 3. Move the build into `keboola-config/setup.sh` so it runs in the Linux container at deploy:
    ```bash
-   # in keboola-config/setup.sh, in the app dir:
-   npm ci && npm run build
-   # Next.js standalone needs static assets copied alongside the server:
-   cp -r frontend/.next/static frontend/.next/standalone/frontend/.next/static
-   cp -r frontend/public      frontend/.next/standalone/frontend/public
+   # in keboola-config/setup.sh, run from the app's frontend dir:
+   cd frontend && npm ci && npm run build
+   # Next.js output:'standalone' does NOT copy static assets — copy them so the
+   # standalone server.js can serve them. The destination MIRRORS the path from the
+   # Next.js workspace root, so it differs by layout — detect where server.js landed:
+   #   find .next/standalone -maxdepth 3 -name server.js
+   # Single-package repo (workspace root == frontend/, server.js at .next/standalone/server.js):
+   cp -r .next/static .next/standalone/.next/static
+   cp -r public       .next/standalone/public
+   # Monorepo (workspace root above frontend/, server.js at .next/standalone/frontend/server.js):
+   #   cp -r .next/static .next/standalone/frontend/.next/static
+   #   cp -r public       .next/standalone/frontend/public
    ```
    For the exact setup.sh / nginx / supervisord wiring, cross-reference the **`dataapp-developer:dataapp-deployment`** skill.
-4. Commit the source-only tree, re-run the size guard (no tracked file >15MB), then push.
+4. Commit the source-only tree, then re-run the size guard (no tracked file >15MB).
 
-If a push still 413s, re-run the size guard and **report the offending file** — the user must decide how to externalize it (it can't be split).
+5. **Check git *history*, not just the working tree (CRITICAL).** `git push` sends every
+   object reachable from the pushed ref — so a build committed in an *earlier* commit still
+   gets pushed and still 413s, even after step 2 removes it from `HEAD`. The `find` guard only
+   sees the working tree. Check reachable blobs:
+   ```bash
+   git rev-list --objects HEAD \
+     | git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' \
+     | awk '$1=="blob" && $2>15000000 {print $2, $3}'
+   ```
+   If anything prints, the over-cap blob is in history. Two remedies:
+   - **Fresh managed repo (the common case):** push a single clean commit so the old blobs
+     are never reachable —
+     ```bash
+     git checkout --orphan clean-main && git add -A && git commit -m "Source-only (build at deploy)"
+     git push keboola clean-main:main
+     ```
+   - **History must be preserved:** purge the blob with `git filter-repo` (or BFG), then push.
+
+If a push still 413s, re-run **both** guards (working tree *and* history) and **report the
+offending file** — the user must decide how to externalize it (it can't be split).
 
 ## 5. Deploy + verify
 

--- a/plugins/keboola-git/skills/keboola-git/references/managed-git.md
+++ b/plugins/keboola-git/skills/keboola-git/references/managed-git.md
@@ -113,18 +113,37 @@ both over-cap *and* the wrong architecture for the Linux deploy runtime.
    ```
 3. **Move the build into `keboola-config/setup.sh`** (runs in the Linux container on startup):
    ```bash
-   npm ci && npm run build
-   # Next.js standalone output needs static assets copied next to the server:
-   cp -r frontend/.next/static frontend/.next/standalone/frontend/.next/static
-   cp -r frontend/public      frontend/.next/standalone/frontend/public
+   cd frontend && npm ci && npm run build
+   # Next.js output:'standalone' does NOT copy static assets — copy them so the standalone
+   # server.js can serve them. Destination MIRRORS the path from the Next.js workspace root,
+   # so it differs by layout. Detect where the build put server.js:
+   #   find .next/standalone -maxdepth 3 -name server.js
+   # Single-package repo (root == frontend/, server.js at .next/standalone/server.js):
+   cp -r .next/static .next/standalone/.next/static
+   cp -r public       .next/standalone/public
+   # Monorepo (root above frontend/, server.js at .next/standalone/frontend/server.js):
+   #   cp -r .next/static .next/standalone/frontend/.next/static
+   #   cp -r public       .next/standalone/frontend/public
    ```
    For the surrounding setup.sh / nginx / supervisord wiring, see the
    `dataapp-developer:dataapp-deployment` skill.
-4. **Re-run the size guard** (must return nothing) and push.
+4. **Re-run the working-tree size guard** (must return nothing).
+5. **Guard git *history*, not just the working tree.** `git push` sends every object reachable
+   from the pushed ref, so a build committed in an *earlier* commit still 413s even after step 2.
+   The `find` guard only sees the working tree. Check reachable blobs:
+   ```bash
+   git rev-list --objects HEAD \
+     | git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' \
+     | awk '$1=="blob" && $2>15000000 {print $2, $3}'
+   ```
+   If anything prints, the over-cap blob is in history. Remedies:
+   - **Fresh managed repo (common):** push one clean commit so old blobs aren't reachable —
+     `git checkout --orphan clean-main && git add -A && git commit -m "Source-only" && git push keboola clean-main:main`.
+   - **Preserve history:** purge the blob with `git filter-repo` (or BFG), then push.
 
-If a push still returns 413, re-run the guard and **report the offending file by name** —
-the user decides how to externalize it (download at deploy, fetch from object storage, etc.).
-You cannot split it.
+If a push still returns 413, re-run **both** guards (working tree *and* history) and **report the
+offending file by name** — the user decides how to externalize it (download at deploy, fetch from
+object storage, etc.). You cannot split it.
 
 ---
 
@@ -133,6 +152,8 @@ You cannot split it.
 | Symptom / situation | Cause | What to do |
 |---|---|---|
 | `HTTP 413` on push | A single tracked file (or total payload) > ~15MB | Source-only + build-at-deploy (above); report the offending file if a single file is over cap |
+| `HTTP 413` even after untracking the build | Over-cap blob still in an **earlier commit** — `git push` sends all reachable history, the `find` guard only sees the working tree | Check `git rev-list --objects HEAD \| git cat-file --batch-check`; push an `--orphan` clean commit (fresh repo) or `git filter-repo`/BFG to purge (preserve history) |
+| Static assets 404 after deploy / blank page | `cp` destination didn't match where `next build` put `server.js` | Destination mirrors the Next.js workspace root — `find .next/standalone -name server.js` and copy `static`/`public` alongside it |
 | Committed `frontend/.next` ~55MB | Build artifacts checked into the repo | `git rm -r --cached`, gitignore, build in `setup.sh` |
 | 15.3MB `sharp` binary | macOS-built native dep, wrong arch for Linux | Don't track it; `npm ci` in container reinstalls the correct Linux binary |
 | `git push keboola :main` / delete fails | Pre-receive hook **declines branch deletes** | Branches only advance; never rely on deleting a remote branch |

--- a/plugins/keboola-git/skills/keboola-git/references/managed-git.md
+++ b/plugins/keboola-git/skills/keboola-git/references/managed-git.md
@@ -160,6 +160,8 @@ object storage, etc.). You cannot split it.
 | Force-push rejected / dangerous | Shared managed branch | Never force-push managed/shared branches |
 | Credential leaked into a commit or log | `git_clone_url` echoed to a file | Rotate immediately (mint a new credential), scrub history; keep the URL in a shell var only |
 | `logs` / `password` command errors on auth | Manage token not in env | Add `--allow-env-manage-token` and ensure the manage token is exported |
-| Deploy succeeds but backend logs data errors | Empty project / missing Storage tables | **Expected** when the target project has no data — the app is running and looking for data; not a git/deploy failure |
-| `POST /` returns non-200 | Frontend not serving | Check build logs (`next build` failed?) and supervisord process state |
+| Deploy succeeds but `python-api` crash-loops on `404 Not Found` at startup | Backend's startup data load hits Storage tables that don't exist in an empty project | **Expected** out-of-scope data error — the app is running and looking for data; not a git/deploy failure. Verify the *frontend* separately (`node-frontend` RUNNING). |
+| `GET /` returns a login page (`<title>Login</title>`, no `_next/static`) | Keboola platform auth gate sits *in front of* the container — it returns 200 regardless of app state | Not a frontend signal. Confirm serving via logs (`node-frontend entered RUNNING`, `Ready in`); to test the app UI, authenticate with the app password first |
+| `POST /` returns 200 but app may not be up | nginx `location = /` returns 200 for POST unconditionally (platform health rule) | Don't use POST `/` as a serving check; rely on `node-frontend entered RUNNING` in the logs |
+| Frontend genuinely not serving | `next build` failed, static `cp` path wrong, or server crashed | Check logs for `Compiled successfully`, `Completed: setup_sh`, and `node-frontend` spawn/RUNNING vs `exited`/`backoff` |
 | kbagent tool call hangs / no output | `KBAGENT_CONVERSATION_ID` unset or `--json` omitted | Export the conversation id; always pass `--json` |

--- a/plugins/keboola-git/skills/keboola-git/references/managed-git.md
+++ b/plugins/keboola-git/skills/keboola-git/references/managed-git.md
@@ -1,0 +1,144 @@
+# Keboola-Managed Git — Reference
+
+Full `kbagent` command catalog, the HTTP 413 / build-at-deploy recipe, and the gotchas
+table for accessing Keboola-managed Forgejo repos for python-js data apps.
+
+All commands assume:
+```bash
+export KBAGENT_CONVERSATION_ID=$(uuidgen)   # once per shell session
+# <alias>  = the kbagent project alias (e.g. e2e-1143)
+# <cfg>    = configuration_id of the prod data-app config
+# <id>     = data_app_id
+```
+Always pass `--json` to `tool call` so output is parseable.
+
+---
+
+## kbagent command catalog
+
+### Provision / find the repo
+
+```bash
+# List existing data apps (find configuration_id, data_app_id, repo_url)
+kbagent --json tool call get_data_apps --project <alias> --input '{}'
+
+# Provision a new python-js data app (creates the managed repo)
+kbagent --json tool call modify_python_js_data_app --project <alias> \
+  --input '{"name":"<Display Name>","slug":"<slug>","description":"<desc>"}'
+```
+**Returns:** `configuration_id`, `data_app_id`, `repo_url`
+(`https://git.<stack>/keboola/app-<data_app_id>.git`).
+
+Two-app model: the **prod** config owns the only repo. Draft branches are advanced from
+prod; there is not a separate repo per draft.
+
+### Mint a push credential (one-time secret)
+
+```bash
+kbagent --json tool call create_python_js_data_app_git_credential --project <alias> \
+  --input '{"configuration_id":"<cfg>"}'
+```
+**Returns:** `git_clone_url` = `https://kai:<secret>@git.<stack>/keboola/app-<id>.git`.
+
+- Secret is shown **once**. Mint a fresh credential anytime; rotation invalidates old ones.
+- Hold it in a shell variable only — never commit, echo to a file, or log it.
+
+### Deploy
+
+```bash
+kbagent --json tool call deploy_data_app --project <alias> \
+  --input '{"action":"deploy","configuration_id":"<cfg>"}'
+```
+
+### Logs / password / secrets (need a manage token in env)
+
+```bash
+# Build + runtime logs (~90s build for npm ci + next build)
+kbagent --allow-env-manage-token data-app logs --project <alias> --app-id <id> --lines 200
+
+# App password (for authenticated probes)
+kbagent --json --allow-env-manage-token data-app password --project <alias> --app-id <id>
+
+# Set an env secret, then redeploy
+kbagent --allow-env-manage-token data-app secrets-set --project <alias> --app-id <id> '#KEY=VAL'
+
+# Delete the app (teardown — confirm first)
+kbagent --json --allow-env-manage-token data-app delete --project <alias> --app-id <id>
+```
+
+---
+
+## Raw-git clone / push pattern
+
+kbagent has **no repo-copy helper**. Drive git yourself from a scratch dir under CWD:
+
+```bash
+mkdir -p ./.keboola-git-work && cd ./.keboola-git-work
+git clone --single-branch --branch <branch> <source-repo> app && cd app
+
+URL='https://kai:<secret>@git.<stack>/keboola/app-<id>.git'   # from step "mint credential"
+git remote add keboola "$URL"
+git push keboola HEAD:main
+```
+
+Reverse direction (Keboola → GitHub scratch):
+```bash
+git clone --single-branch --branch main "$URL" app && cd app
+git remote add github <scratch-repo-url>
+git push github main:<scratch-branch>     # never a shared branch; never --force
+```
+
+---
+
+## HTTP 413 / build-at-deploy recipe
+
+Forgejo rejects pushes larger than **~15MB** with **HTTP 413 Payload Too Large**. A single
+file over the cap **cannot be split** — it must not be tracked at all.
+
+The headline offender: repos that **commit their build**. Example — a Next.js app committing
+`frontend/.next/` (~55MB), which also bundles a 15.3MB macOS `sharp` native binary that is
+both over-cap *and* the wrong architecture for the Linux deploy runtime.
+
+**Fix — push source only, build in the container at deploy:**
+
+1. **Size guard** (run before every push):
+   ```bash
+   find . -size +15M -not -path '*/.git/*'
+   ```
+2. **Untrack + gitignore the build:**
+   ```bash
+   git rm -r --cached frontend/.next
+   printf '%s\n' 'frontend/.next/' 'node_modules/' >> .gitignore
+   git add -A && git commit -m "Source-only: build at deploy"
+   ```
+3. **Move the build into `keboola-config/setup.sh`** (runs in the Linux container on startup):
+   ```bash
+   npm ci && npm run build
+   # Next.js standalone output needs static assets copied next to the server:
+   cp -r frontend/.next/static frontend/.next/standalone/frontend/.next/static
+   cp -r frontend/public      frontend/.next/standalone/frontend/public
+   ```
+   For the surrounding setup.sh / nginx / supervisord wiring, see the
+   `dataapp-developer:dataapp-deployment` skill.
+4. **Re-run the size guard** (must return nothing) and push.
+
+If a push still returns 413, re-run the guard and **report the offending file by name** —
+the user decides how to externalize it (download at deploy, fetch from object storage, etc.).
+You cannot split it.
+
+---
+
+## Gotchas table
+
+| Symptom / situation | Cause | What to do |
+|---|---|---|
+| `HTTP 413` on push | A single tracked file (or total payload) > ~15MB | Source-only + build-at-deploy (above); report the offending file if a single file is over cap |
+| Committed `frontend/.next` ~55MB | Build artifacts checked into the repo | `git rm -r --cached`, gitignore, build in `setup.sh` |
+| 15.3MB `sharp` binary | macOS-built native dep, wrong arch for Linux | Don't track it; `npm ci` in container reinstalls the correct Linux binary |
+| `git push keboola :main` / delete fails | Pre-receive hook **declines branch deletes** | Branches only advance; never rely on deleting a remote branch |
+| Force-push rejected / dangerous | Shared managed branch | Never force-push managed/shared branches |
+| Credential leaked into a commit or log | `git_clone_url` echoed to a file | Rotate immediately (mint a new credential), scrub history; keep the URL in a shell var only |
+| `logs` / `password` command errors on auth | Manage token not in env | Add `--allow-env-manage-token` and ensure the manage token is exported |
+| Deploy succeeds but backend logs data errors | Empty project / missing Storage tables | **Expected** when the target project has no data — the app is running and looking for data; not a git/deploy failure |
+| `POST /` returns non-200 | Frontend not serving | Check build logs (`next build` failed?) and supervisord process state |
+| kbagent tool call hangs / no output | `KBAGENT_CONVERSATION_ID` unset or `--json` omitted | Export the conversation id; always pass `--json` |


### PR DESCRIPTION
## What

New standalone **`keboola-git`** plugin (v1.0.0) giving Claude Code the context to access **Keboola-managed Git (Forgejo)** repos for python-js data apps via the `kbagent` CLI — provision a repo, mint a one-time push credential, push source with raw `git`, and deploy.

The headline gotcha it encodes: the **~15MB / HTTP 413** push cap on managed git, which forces a **build-at-deploy** approach for repos that commit their build.

## Contents

- `skills/keboola-git/SKILL.md` — provision/find the repo, mint `git_clone_url`, raw clone/push, 413 + build-at-deploy recipe, deploy + verify
- `skills/keboola-git/references/managed-git.md` — full kbagent command catalog, 413/build-at-deploy recipe, gotchas table
- `commands/keboola-git-copy.md` — bidirectional `to-keboola | to-github` copy with size guard + scratch-branch safety
- `.claude-plugin/plugin.json` (v1.0.0, **no mcpServers** — kbagent-CLI driven), plugin `README.md`
- Wired into `.claude-plugin/marketplace.json` + root `README.md`

`claude plugin validate .` passes.

## E2E verification

Verified end-to-end on `99_Playground_Max` (project 1143) using `keboola/profitline-js-app@dev-max` (commits its build → exercises the 413/build-at-deploy path):

- **Forward (GitHub→Keboola):** provision → mint credential → clone → size guard caught committed `frontend/.next` (~55MB incl. 15.3MB macOS `sharp` dylib) → applied build-at-deploy + clean history → pushed **no 413** → deployed → `next build ✓ 43s` → **frontend serves (GET / 200) + backend up (GET /api/ 200)**.
- **Reverse (Keboola→GitHub):** managed `main` pushed to a user-owned scratch branch, SHA-matched, no force, shared repo untouched.
- Test app + scratch resources torn down after.

## Notes

- Did **not** run `bump-version.sh` (it rewrites every version globally); marketplace entry hand-edited, new plugin starts at 1.0.0 per repo conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)