### PR TITLE
fix: align dataapp-developer skill with renamed modify_streamlit_data_app MCP tool

### DIFF
--- a/plugins/dataapp-developer/skills/dataapp-development/SKILL.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/SKILL.md
@@ -35,7 +35,7 @@ If unsure → `references/choosing-app-type.md`. Short version:
 
 `references/deployment-paths.md` covers all three:
 
-- **Path A — Claude Desktop / web (MCP-only, no filesystem):** Use `modify_data_app` / `deploy_data_app` MCP tools (Streamlit only today).
+- **Path A — Claude Desktop / web (MCP-only, no filesystem):** Use `modify_streamlit_data_app` / `deploy_data_app` MCP tools (Streamlit only today).
 - **Path B — Claude Code / local agent with filesystem + MCP:** Edit files locally, push to customer git, deploy via MCP or kbagent.
 - **Path C — CLI agent (`kbagent`):** Full lifecycle via `kbagent data-app` command group.
 
@@ -75,5 +75,5 @@ The Keboola MCP server exposes a `docs_query` tool that searches the official Ke
 5. **Never declare `[program:nginx]`** in `keboola-config/supervisord/`. Nginx is managed by the base image.
 6. **Validate data first, code second.** When using Keboola MCP, call `get_table` and `query_data` to confirm schema before writing SQL. If the project has a semantic layer, check it first via `search_semantic_context` / `get_semantic_context` and ground the query in those definitions rather than inventing the calculation. See `references/dev-workflow.md`.
 7. **Pick one Keboola path per session.** Before any project-mutating call, run BOTH detection checks (`which kbagent` + scan for `mcp__*[Kk]eboola*` tools) and ask the user which to use if more than one is present. Don't silently pick. See `references/deployment-paths.md` §Pick one path per session.
-8. **MCP-only flows: compose source directly into the tool call.** When the chosen path is `modify_data_app`, the `source_code` argument **is** the deployment artifact — don't pre-write a local copy. See `references/deployment-paths.md` Path A.
+8. **MCP-only flows: compose source directly into the tool call.** When the chosen path is `modify_streamlit_data_app`, the `source_code` argument **is** the deployment artifact — don't pre-write a local copy. See `references/deployment-paths.md` Path A.
 9. **For local-dev credentials: pre-fill what you can, ask for what's missing, then offer to run.** Never grep the filesystem or scan unrelated env vars for tokens. See `references/storage-access.md` §Getting the env vars for local development.

--- a/plugins/dataapp-developer/skills/dataapp-development/TODO.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/TODO.md
@@ -16,11 +16,11 @@ Open Linear issues whose resolution will change what the skill teaches. Until th
 
 Gaps that force the skill to recommend kbagent or filesystem paths for things MCP should cover.
 
-- **`modify_data_app` is Streamlit-only.** No Python/JS app creation or modification via MCP. Blocks Path A for dashboarding apps. See `references/python-js-apps.md` §"Deployment via MCP — PLACEHOLDER".
-- **No Git deployment mode via MCP.** `modify_data_app` only supports Code mode. Git-mode apps (the recommended choice for multi-file projects) require the Configuration API or kbagent.
+- **`modify_streamlit_data_app` is Streamlit-only.** No Python/JS app creation or modification via MCP. Blocks Path A for dashboarding apps. See `references/python-js-apps.md` §"Deployment via MCP — PLACEHOLDER".
+- **No Git deployment mode via MCP.** `modify_streamlit_data_app` only supports Code mode. Git-mode apps (the recommended choice for multi-file projects) require the Configuration API or kbagent.
 - **No log-reading tool beyond the 20-line tail.** `get_data_apps(...).deployment_info.logs` returns only the most recent lines. For real debugging the agent has to direct the user to the Keboola UI Terminal Log tab.
 - **No workspace management.** Cannot create / grant / list / delete workspaces via MCP. Local-dev workspace setup falls back to UI or kbagent.
-- **No direct secret management.** Adding / removing / listing `dataApp.secrets` has to go through `modify_data_app` (which couples it to source-code edits) or the Configuration API directly.
+- **No direct secret management.** Adding / removing / listing `dataApp.secrets` has to go through `modify_streamlit_data_app` (which couples it to source-code edits) or the Configuration API directly.
 - **No Storage Access toggle.** Enabling Storage Access on an app config requires UI navigation; no MCP affordance.
 - **No project-feature discovery.** Agents can't programmatically detect whether the direct-grant feature is enabled on the project — currently has to ask the user or read error responses.
 
@@ -36,7 +36,7 @@ Smaller gaps; kbagent already covers most of the data-app lifecycle.
 Sections we know are incomplete because the underlying pattern isn't firm yet. Mostly tracked by Linear above, but listed here as the writing tasks.
 
 - **`storage-access.md` §Data access management — PLACEHOLDER.** Per-user / row-level data access control. No documented pattern; internal apps diverge. Cross-referenced from `authentication.md`.
-- **`python-js-apps.md` §Deployment via MCP — PLACEHOLDER.** Fill in once `modify_data_app` covers Python/JS.
+- **`python-js-apps.md` §Deployment via MCP — PLACEHOLDER.** Fill in once `modify_streamlit_data_app` covers Python/JS.
 - **SQL helpers in Query Service SDKs.** Once `SQL.literal()` / `SQL.ident()` / `sql.format()` ship in `keboola-query-service` (Py) and `@keboola/query-service` (JS), replace the manual sanitization patterns in `storage-access.md` §SQL injection with SDK-driven examples.
 - **BigQuery RW path.** Add once BigQuery Storage Access lands (see Platform section above).
 - **Two Max Ottomansky suggestions from AI-3147 not yet picked up:**

--- a/plugins/dataapp-developer/skills/dataapp-development/references/authentication.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/authentication.md
@@ -5,7 +5,7 @@
 ## Options overview
 
 Keboola Data Apps ship with six built-in authentication methods. All of them
-are configured on the app itself (in the Keboola UI or via `modify_data_app`)
+are configured on the app itself (in the Keboola UI or via `modify_streamlit_data_app`)
 and do not require any code changes inside the app.
 
 - **None** — app is publicly accessible by URL. Implement your own auth in
@@ -67,7 +67,7 @@ If you need rotatable passwords, multiple users, MFA, or any kind of access audi
 
 ## MCP defaults
 
-When using `modify_data_app` via MCP:
+When using `modify_streamlit_data_app` via MCP:
 
 - **New apps** default to `basic-auth` for security if `authentication_type` is not specified.
 - **Updates to existing apps** — pass `authentication_type="default"` to preserve the existing setup. Important: passing `"basic-auth"` on an UPDATE to an OIDC app will silently DOWNGRADE it to basic-auth. Always use `"default"` on updates unless you explicitly intend to change the auth method.

--- a/plugins/dataapp-developer/skills/dataapp-development/references/choosing-app-type.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/choosing-app-type.md
@@ -46,7 +46,7 @@ Stack: Express (or similar) on a single port, serving both `/api/*` JSON endpoin
 | Frontend bundler | No | No | Yes |
 | Backend language | Python | Node | Python + Node |
 | Deploy mode | Code or Git | Git only | Git only |
-| MCP support today | Yes (`modify_data_app`) | No (use kbagent or git) | No (use kbagent or git) |
+| MCP support today | Yes (`modify_streamlit_data_app`) | No (use kbagent or git) | No (use kbagent or git) |
 | Cold-start time | Fast | Fastest | Slowest |
 
 ## Migration notes

--- a/plugins/dataapp-developer/skills/dataapp-development/references/deployment-paths.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/deployment-paths.md
@@ -31,7 +31,7 @@ When phrasing the question, present each path with its trade-offs honestly. Alwa
 
 > I see both an MCP server (`keboola-test` → branch 35403) and kbagent (`new-branches` alias → project 3047, branch 37363) available, with filesystem access. Two viable paths:
 >
-> - **MCP-only**: compose source into `modify_data_app`, deploy via `deploy_data_app`, debug via platform logs. No CLI work on your machine, no local environment to manage.
+> - **MCP-only**: compose source into `modify_streamlit_data_app`, deploy via `deploy_data_app`, debug via platform logs. No CLI work on your machine, no local environment to manage.
 > - **kbagent + local iteration**: edit `streamlit_app.py` locally, run with `streamlit run` against the workspace, deploy via `kbagent data-app deploy` when it works. Faster iteration loop for non-trivial apps — but you'll be filling in `.env.local`, running shell commands, and debugging CLI output. Expect to hit a few CLI gotchas along the way.
 >
 > Which would you like? Note: these paths may resolve to different branches or projects.
@@ -44,7 +44,7 @@ The trade-off is not just "which works" — it's iteration speed.
 
 | Path | Iteration loop | Best for |
 |---|---|---|
-| **MCP-only (Path A)** | Each edit → `modify_data_app` → `deploy_data_app` → wait for container spin-up → check logs via MCP → repeat | Small or quick apps where the first try is close. Demos. No filesystem assumed. |
+| **MCP-only (Path A)** | Each edit → `modify_streamlit_data_app` → `deploy_data_app` → wait for container spin-up → check logs via MCP → repeat | Small or quick apps where the first try is close. Demos. No filesystem assumed. |
 | **kbagent + filesystem (Path B/C)** | Edit `streamlit_app.py` locally → `streamlit run` against real workspace creds in `.env.local` → verify in browser → only then `kbagent data-app deploy` or `git push` | Non-trivial apps. You catch SQL errors, missing columns, layout bugs locally where the loop is seconds. Only ship a working version. |
 
 The MCP loop can be much slower for any app that needs more than one or two corrections — every cycle pays the platform's container spin-up cost (tens of seconds). The local-iterate-then-deploy loop runs at editor speed.
@@ -57,17 +57,17 @@ Once the user picks, **don't use the others, not even for unrelated operations l
 
 The defining constraint of this path is **the only channel to Keboola is MCP**. The agent may have a sandbox filesystem (Claude Desktop now does), a Python runner, a Bash tool — but none of those connect to your Keboola project. They run in the agent's local workspace, isolated. Anything that needs to reach Keboola — source code, deploy commands, log reads — has to go through an MCP tool call.
 
-This matters most for the `modify_data_app` flow: the `source_code` argument **is** the deployment artifact. Writing the same code to the sandbox FS first and then re-emitting it as the tool argument doubles output tokens for no benefit. The sandbox FS is useful for scratchpad iteration (cheap `str_replace` edits before a single expensive emit) but the artifact lives in the tool call, not the file.
+This matters most for the `modify_streamlit_data_app` flow: the `source_code` argument **is** the deployment artifact. Writing the same code to the sandbox FS first and then re-emitting it as the tool argument doubles output tokens for no benefit. The sandbox FS is useful for scratchpad iteration (cheap `str_replace` edits before a single expensive emit) but the artifact lives in the tool call, not the file.
 
 Available tools:
 
-- `modify_data_app` — creates or updates the source code IN the data app configuration (no separate git repo).
+- `modify_streamlit_data_app` — creates or updates the source code IN the data app configuration (no separate git repo).
 - `deploy_data_app(action="deploy", configuration_id=...)` — deploys or restarts the app.
 - `deploy_data_app(action="stop", configuration_id=...)` — suspends.
 - `get_data_apps([cfg_id])` — returns the latest 20 log lines for debugging.
 - `query_data`, `get_table`, `get_project_info` — for validating data before writing code.
 
-After `modify_data_app`, ALWAYS call `deploy_data_app(action="deploy")` — without this, changes do not take effect. The existing running app keeps serving the previous code.
+After `modify_streamlit_data_app`, ALWAYS call `deploy_data_app(action="deploy")` — without this, changes do not take effect. The existing running app keeps serving the previous code.
 
 For new apps, pass `configuration_id=""`. For updates, pass the existing configuration ID and a non-empty `change_description`.
 
@@ -75,18 +75,18 @@ For `authentication_type` defaults and the OIDC-downgrade footgun on updates, se
 
 **Limitations:** Streamlit type only. No Git deployment mode via MCP. No Python/JS type via MCP today (planned — see [python-js-apps.md](python-js-apps.md) "Deployment via MCP — PLACEHOLDER").
 
-**Don't write the source to a local file first.** Even when the runtime gives you a sandbox filesystem (Claude Desktop does), the `source_code` argument is the source of truth — the platform stores it directly in the data-app configuration. Drafting to `/home/claude/streamlit_app.py` and then re-emitting it as the tool argument doubles your output tokens for no benefit. Compose the code directly into the `modify_data_app` call. If you want a review step before deploy, draft the code in your reply, get user confirmation, then make the tool call once.
+**Don't write the source to a local file first.** Even when the runtime gives you a sandbox filesystem (Claude Desktop does), the `source_code` argument is the source of truth — the platform stores it directly in the data-app configuration. Drafting to `/home/claude/streamlit_app.py` and then re-emitting it as the tool argument doubles your output tokens for no benefit. Compose the code directly into the `modify_streamlit_data_app` call. If you want a review step before deploy, draft the code in your reply, get user confirmation, then make the tool call once.
 
 The one legitimate exception: if the source is large enough that you genuinely need cheap iterative edits before a single expensive emit (e.g. via `str_replace` against a sandboxed file), use the local copy as a scratchpad — but only that, and only if the iteration savings beat the redundant emit. For small apps (<100 lines), compose-in-tool is always cheaper.
 
 Local files only become deployment artifacts on Paths B and C (git push or kbagent). The "local development" instructions in [streamlit-apps.md](streamlit-apps.md) and [python-js-apps.md](python-js-apps.md) apply to those paths, not to Path A.
 
-**Debug loop:** if the app fails to start or behaves wrong after deploy, call `get_data_apps(<cfg_id>)` for the latest 20 log lines, fix the `source_code`, call `modify_data_app` again with a `change_description`, then `deploy_data_app(action="deploy")`. Repeat. There is no way to attach to a shell or read arbitrary log files from this path.
+**Debug loop:** if the app fails to start or behaves wrong after deploy, call `get_data_apps(<cfg_id>)` for the latest 20 log lines, fix the `source_code`, call `modify_streamlit_data_app` again with a `change_description`, then `deploy_data_app(action="deploy")`. Repeat. There is no way to attach to a shell or read arbitrary log files from this path.
 
 Minimal example call signature (annotated, not executable):
 
 ```python
-modify_data_app(
+modify_streamlit_data_app(
     name="My App",
     description="...",
     source_code="""
@@ -110,7 +110,7 @@ The most flexible path. Edit code locally with Read/Edit/Write tools. Use Playwr
 
 For **Streamlit** apps:
 
-- Code mode: edit local file, then push to git OR use `modify_data_app` to paste the contents into the data app config.
+- Code mode: edit local file, then push to git OR use `modify_streamlit_data_app` to paste the contents into the data app config.
 - Git mode: edit local file, `git push`, then `deploy_data_app` via MCP picks up the new commit.
 
 For **Python/JS** apps:
@@ -128,7 +128,7 @@ Best fit for:
 
 1. Validate data with `query_data` / `get_table` (MCP).
 2. Edit code locally with Read/Edit/Write.
-3. Push to git (Python/JS) or paste via `modify_data_app` (Streamlit Code mode).
+3. Push to git (Python/JS) or paste via `modify_streamlit_data_app` (Streamlit Code mode).
 4. `deploy_data_app(action="deploy", ...)` via MCP, or `kbagent data-app deploy --wait` if Path C.
 5. Open the running app in Playwright MCP, take a screenshot, iterate.
 

--- a/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
@@ -12,7 +12,7 @@ Source: https://github.com/keboola/mcp-server
 
 The MCP server that exposes Keboola tools to agents. Provides:
 
-- **Data app lifecycle:** `modify_data_app`, `deploy_data_app`, `get_data_apps` (Streamlit only today).
+- **Data app lifecycle:** `modify_streamlit_data_app`, `deploy_data_app`, `get_data_apps` (Streamlit only today).
 - **Data validation:** `get_project_info`, `get_table`, `query_data`, `search`.
 - **Docs lookup:** `docs_query` — searches the Keboola Connection documentation. Prefer this over guessing from memory.
 - **Config management:** `get_components`, `find_component_id`, `get_configs`, `create_config`, `update_config`, `add_config_row`, `update_config_row`, `run_sync_action`.

--- a/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
@@ -114,13 +114,13 @@ Full reference and runnable harness: [duckdb-caching.md](duckdb-caching.md) and 
 ## Direct RO workspace queries
 
 Use this when:
-- You're using the MCP `modify_data_app` flow and the `{QUERY_DATA_FUNCTION}` placeholder gets injected automatically — most agent-driven Streamlit creation works this way.
+- You're using the MCP `modify_streamlit_data_app` flow and the `{QUERY_DATA_FUNCTION}` placeholder gets injected automatically — most agent-driven Streamlit creation works this way.
 - The cached dataset would be too large for an in-memory cache, OR the freshness requirement is sub-minute.
 - You're prototyping and haven't wired DuckDB yet.
 
 Two paths to call the workspace:
 
-- **MCP-injected `query_data`** — when `modify_data_app` is involved, a `query_data(sql) -> pd.DataFrame` function is dropped into the source code via the `{QUERY_DATA_FUNCTION}` placeholder. Use it as-is; don't roll your own.
+- **MCP-injected `query_data`** — when `modify_streamlit_data_app` is involved, a `query_data(sql) -> pd.DataFrame` function is dropped into the source code via the `{QUERY_DATA_FUNCTION}` placeholder. Use it as-is; don't roll your own.
 - **Query Service via the official SDK** — for Python/JS apps without MCP injection, call the Query Service API (`https://query.<stack>.keboola.com/api/v1/...`) using `keboola-query-service` (Python) or `@keboola/query-service` (JS/TS). The SDK handles submit + poll + paginate; you call `executeQuery({ branchId, workspaceId, statements })` and get back columns + rows.
 
 **Do NOT post to `/v2/storage/branch/<b>/workspaces/<w>/query`.** That was an older Storage API workspace-query endpoint that survives in some docs and templates, but it returns `workspace.workspaceNotFound` 404s on most Snowflake projects today. Use the Query Service.

--- a/plugins/dataapp-developer/skills/dataapp-development/references/streamlit-apps.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/streamlit-apps.md
@@ -163,7 +163,7 @@ If you reach this question, you usually want both — `@st.cache_resource` for t
 
 ## Local development
 
-**This section applies to git-deployed apps (Path B / C in [deployment-paths.md](deployment-paths.md)) and to humans iterating on a checkout.** If you're an agent deploying via `modify_data_app` (Path A), skip — the tool argument is the deployment artifact, there's no local-vs-prod parity to maintain, and even Claude Desktop's sandbox filesystem doesn't change that. Compose the source code directly into the tool call.
+**This section applies to git-deployed apps (Path B / C in [deployment-paths.md](deployment-paths.md)) and to humans iterating on a checkout.** If you're an agent deploying via `modify_streamlit_data_app` (Path A), skip — the tool argument is the deployment artifact, there's no local-vs-prod parity to maintain, and even Claude Desktop's sandbox filesystem doesn't change that. Compose the source code directly into the tool call.
 
 Running the app on your laptop should look like Keboola without trying to be Keboola. Same code, same secrets shape, same `streamlit_app.py` entrypoint -- only the source of the credentials changes.
 


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2852/fix-mcp-for-streamlit-and-cc)

## Description

The Keboola MCP server renamed the Streamlit data-app tool `modify_data_app` → `modify_streamlit_data_app` (`keboola/mcp-server` AI-3005, 2026-05-24) and split out a separate `modify_python_js_data_app`. The `dataapp-developer` skill still instructed agents to call the old `modify_data_app`, which no longer exists on the server.

An agent following the skill calls `modify_data_app`, the tool is not found, and the call fails — with no working fallback, since `update_config` is intentionally blocked for data-app components by `check_suitable`.

This change renames all 24 references from `modify_data_app` to `modify_streamlit_data_app` across the skill (`SKILL.md`, `TODO.md`, and the `references/` files: `authentication.md`, `choosing-app-type.md`, `deployment-paths.md`, `glossary.md`, `storage-access.md`, `streamlit-apps.md`). It is a pure rename — the tool's parameters (`source_code`, `change_description`, `configuration_id`) are unchanged, so the documented call signatures stay accurate.

## Release Notes

- **Justification**
    - The MCP side of AJDA-2852 point 1 (two tool names for one operation, only one works) is already resolved on the server by the rename; the remaining gap was the agent guidance, which still pointed at the dead tool name. This aligns the `dataapp-developer` skill with the live MCP tool surface.
    - In plain terms: the assistant's instructions told it to use a tool that had been renamed, so it would fail when trying to create or edit a Streamlit data app. The instructions now use the current tool name.
- **Plans for Customer Communication**
    - No customer communication needed. Documentation/skill-content change only.
- **Impact Analysis**
    - Affects agents that load the `dataapp-developer` skill when creating/editing Streamlit data apps. Before this change they were steered to a non-existent tool; after it they call the correct one. No effect on single-tenant setups or runtime behavior of the MCP server itself.
    - Not behind a feature flag.
- **Deployment Plan**
    - Merges to `main` in the `ai-kit` marketplace; picked up by agents on the next skill sync. No staged rollout needed.
- **Rollback Plan**
    - Fully reversible by reverting the commit. No one-way-door change.
- **Post-Release Support Plan**
    - No special monitoring required. Support team does not need to be notified.
