### PR TITLE
feat(dataapp-developer): add semantic-layer-usage skill (AI-3520)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "dataapp-developer",
       "description": "Toolkit for building and deploying Keboola Apps (Streamlit and Python/JS) — full lifecycle: choosing app type, deployment paths, storage access, authentication, DuckDB caching, styling, dashboard patterns, optional Kai chat, and the validate-build-verify dev workflow.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "source": "./plugins/dataapp-developer",
       "category": "development"
     },

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A specialized toolkit for building production-ready Keboola Python components fo
 A toolkit for building and deploying data apps to Keboola — Streamlit development with validate/build/verify workflow, plus deployment guides for Node.js, Python, and any web framework.
 
 **Features:**
-- 🎯 **Skill**: Single `dataapp-development` skill covering both Streamlit and Python/JS apps with 14 topical references
+- 🎯 **Skills**: `dataapp-development` covering both Streamlit and Python/JS apps with 14 topical references, plus `semantic-layer-usage` for resolving logical semantic-model names to physical Storage identifiers before querying
 - 🚀 **App Types**: Streamlit (Code or Git), single Node.js + static (dashboarding default), combined Python + Node
 - 💾 **Storage**: RO workspace (default), RW direct access via Query Service, input mapping (legacy)
 - 🔒 **Authentication**: None / Basic / OIDC / GitHub / GitLab / JumpCloud

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A specialized toolkit for building production-ready Keboola Python components fo
 A toolkit for building and deploying data apps to Keboola — Streamlit development with validate/build/verify workflow, plus deployment guides for Node.js, Python, and any web framework.
 
 **Features:**
-- 🎯 **Skills**: `dataapp-development` covering both Streamlit and Python/JS apps with 14 topical references, plus `semantic-layer-usage` for resolving logical semantic-model names to physical Storage identifiers before querying
+- 🎯 **Skills**: `dataapp-development` covering both Streamlit and Python/JS apps with 14 topical references, plus `semantic-layer-usage` for confirming a semantic model's physical columns before querying
 - 🚀 **App Types**: Streamlit (Code or Git), single Node.js + static (dashboarding default), combined Python + Node
 - 💾 **Storage**: RO workspace (default), RW direct access via Query Service, input mapping (legacy)
 - 🔒 **Authentication**: None / Basic / OIDC / GitHub / GitLab / JumpCloud

--- a/plugins/dataapp-developer/.claude-plugin/plugin.json
+++ b/plugins/dataapp-developer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataapp-developer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Toolkit for building and deploying Keboola Apps (Streamlit and Python/JS) — full lifecycle: choosing app type, deployment paths, storage access, authentication, DuckDB caching, styling, dashboard patterns, optional Kai chat, and the validate-build-verify dev workflow.",
   "author": {
     "name": "Keboola :(){:|:&};: s.r.o.",

--- a/plugins/dataapp-developer/README.md
+++ b/plugins/dataapp-developer/README.md
@@ -1,6 +1,6 @@
 # Data App Developer Plugin
 
-Toolkit for building and deploying Keboola Apps. Provides a single skill, `dataapp-development`, that covers the full lifecycle (Streamlit and Python/JS app types, three client paths, storage access, authentication, styling, caching, dashboarding, Kai integration, dev workflow, troubleshooting) with 14 topical references and 5 runnable templates.
+Toolkit for building and deploying Keboola Apps. Provides `dataapp-development`, which covers the full lifecycle (Streamlit and Python/JS app types, three client paths, storage access, authentication, styling, caching, dashboarding, Kai integration, dev workflow, troubleshooting) with 14 topical references and 5 runnable templates, plus `semantic-layer-usage` for grounding apps and queries in a semantic model without mistaking logical names for physical Storage identifiers.
 
 ## Available Skills
 
@@ -39,6 +39,17 @@ Toolkit for building and deploying Keboola Apps. Provides a single skill, `dataa
 - Debug deployment or runtime issues
 - Migrate between app types
 
+### semantic-layer-usage
+
+**Activation:** Automatic when building an app, query, report, or transformation from a Keboola semantic layer / semantic model, or right after a semantic-context tool returns.
+
+**What it covers:**
+
+- The semantic layer is a *logical* model — its entity/metric/field names are not guaranteed to equal physical bucket/table/column identifiers
+- The mandatory verification loop before writing any SQL: read the semantic definition, resolve each logical object to its physical Storage identifier (`get_buckets` → `get_tables` → `get_table`), confirm exact column names, and probe with a `query_data` `SELECT … LIMIT 1`
+- Using the fully-qualified physical identifier exactly as returned by `get_table` (per-backend FQN quoting)
+- A worked example of the failure it prevents (semantic field name ≠ physical column in `out.c-nyc-aggregations-duckdb.rpt_*`)
+
 ## MCP Servers
 
 | Server | Type | Purpose |
@@ -53,16 +64,18 @@ plugins/dataapp-developer/
 ├── .claude-plugin/
 │   └── plugin.json
 ├── skills/
-│   └── dataapp-development/
-│       ├── SKILL.md          # router
-│       ├── references/       # 14 topical references
-│       └── templates/        # 5 runnable starter templates
+│   ├── dataapp-development/
+│   │   ├── SKILL.md          # router
+│   │   ├── references/       # 14 topical references
+│   │   └── templates/        # 5 runnable starter templates
+│   └── semantic-layer-usage/
+│       └── SKILL.md          # logical→physical resolution before querying
 └── README.md
 ```
 
 ## Version
 
-1.3.0
+1.4.0
 
 ## Maintainer
 

--- a/plugins/dataapp-developer/README.md
+++ b/plugins/dataapp-developer/README.md
@@ -45,10 +45,9 @@ Toolkit for building and deploying Keboola Apps. Provides `dataapp-development`,
 
 **What it covers:**
 
-- The semantic layer is a *logical* model — its entity/metric/field names are not guaranteed to equal physical bucket/table/column identifiers
-- The mandatory verification loop before writing any SQL: read the semantic definition, resolve each logical object to its physical Storage identifier (`get_buckets` → `get_tables` → `get_table`), confirm exact column names, and probe with a `query_data` `SELECT … LIMIT 1`
-- Using the fully-qualified physical identifier exactly as returned by `get_table` (per-backend FQN quoting)
-- A worked example of the failure it prevents (semantic field name ≠ physical column in `out.c-nyc-aggregations-duckdb.rpt_*`)
+- The semantic layer already carries the physical mapping (`semantic-dataset` `tableId`/`fqn`, `semantic-metric` SQL) — the business-facing display names are labels, not physical columns
+- The one rule the MCP system-prompt workflow doesn't spell out: confirm the real columns via Keboola MCP (e.g. `get_table` on the dataset's `tableId`) and use the metric SQL verbatim before embedding any query
+- A worked example of the failure it prevents (dashboard built from semantic display names ≠ physical columns in `out.c-nyc-aggregations-duckdb.rpt_*`)
 
 ## MCP Servers
 
@@ -69,7 +68,7 @@ plugins/dataapp-developer/
 │   │   ├── references/       # 14 topical references
 │   │   └── templates/        # 5 runnable starter templates
 │   └── semantic-layer-usage/
-│       └── SKILL.md          # logical→physical resolution before querying
+│       └── SKILL.md          # confirm physical columns before querying
 └── README.md
 ```
 

--- a/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
+++ b/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
@@ -1,106 +1,56 @@
 ---
 name: semantic-layer-usage
-description: Use when building an app, query, report, or transformation from a Keboola semantic layer / semantic model, or right after a semantic-context tool returns. The semantic layer is a LOGICAL model — its entity/metric/field names are NOT guaranteed to match physical table/column identifiers. Resolve each logical object to its physical Storage identifier and confirm real columns before writing any SQL.
+description: Use right after a Keboola semantic-context tool returns, when building an app, query, report, or transformation from a semantic model. Ground the SQL in the model's own physical mapping (dataset `tableId`/`fqn`, metric SQL) and confirm the real columns before writing any query — do not build SQL from the business-facing display names.
 ---
 
 # Using the Keboola semantic layer safely
 
-The semantic layer is a **logical model**. It describes metrics, entities, and
-fields in business terms and stores the *definition* of a calculation (its SQL,
-the dataset it belongs to, the join paths between datasets). It is **not** a
-guarantee about physical Storage naming: a semantic field called `total_revenue`
-or an entity called `Trips` will frequently **not** exist under that name as a
-physical column or table. The mapping between logical and physical is exactly
-what you must resolve — never assume it.
+The Keboola MCP system prompt already documents the semantic-layer workflow
+(discover with `search_semantic_context`, inspect with `get_semantic_context`,
+`validate_semantic_query`, then `query_data`). This skill adds the one failure
+mode that workflow does not spell out.
 
-Trusting logical names as if they were physical identifiers is the single most
-common way a semantic-layer-backed app ships broken: the SQL references columns
-that don't exist, every query errors or returns empty, and the app renders a
-blank or error screen.
+**The semantic layer already carries the physical mapping — use it, don't
+bypass it.** A `semantic-dataset` returns its `tableId` and `fqn`; a
+`semantic-metric` returns its SQL. The business-facing display names (a field
+labelled `Total Revenue`, an entity `Trips`) are *not* the physical columns —
+they are labels on top of the definition. The failure is writing SQL from those
+labels instead of from the definition the tools already gave you.
 
-## Mandatory verification loop — before writing ANY SQL/query
+## The one rule
 
-Do this for **every** logical object you plan to touch. Do not skip it because
-the names "look obvious".
-
-**Step 1 applies only when a semantic layer/model is present. Steps 2–4 are the
-floor and always apply** — whether you started from a semantic model, a bare
-Storage table, or a user's business-language request. If no semantic model
-exists (or none matches the request), say so and go straight to steps 2–4
-against the raw tables.
-
-1. **(If a semantic model is available) Read the semantic definition.**
-   `mcp__keboola__search_semantic_context` to find the relevant
-   metric/entity/dataset, then `mcp__keboola__get_semantic_context` to read its
-   SQL, the dataset's identifier, and join paths. Use the metric's calculation
-   **verbatim** — don't reinvent it. If nothing relevant is returned, treat the
-   source as raw Storage and continue with steps 2–4.
-2. **Resolve to physical Storage identifiers.** Map each logical dataset/entity
-   (or the user's described table) to a real bucket + table with
-   `mcp__keboola__get_buckets` → `mcp__keboola__get_tables`, then
-   `mcp__keboola__get_table(table_id=...)` for the chosen table. `get_table`
-   returns the **exact column names** (with case), data types, and the
-   `fully_qualified_name` / `fqn` to use in queries.
-3. **Confirm column names.** Match every field you plan to select to a real
-   column from `get_table`. If a semantic field has no obvious physical column,
-   it is derived — read the semantic SQL to see how it's computed; do not guess
-   a column name.
-4. **Probe before committing.** Run a cheap `mcp__keboola__query_data` probe —
-   `SELECT <cols> FROM <fqn> LIMIT 1` — against the resolved physical identifiers
-   to prove the table, columns, and quoting are correct **before** you write them
-   into app, transformation, or report code.
-
-Write the real query only after the applicable steps pass. When you did start
-from a semantic model and the project exposes
-`mcp__keboola__validate_semantic_query`, run it too — it catches mismatches
-against the semantic model before the SQL is embedded.
-
-## Use fully-qualified physical identifiers, exactly as returned
-
-Write queries with the exact identifier string from `get_table`, never a
-hand-derived one:
-
-- **Snowflake** — full 3-part FQN with double quotes:
-  `"KBC_REGION_PROJID"."out.c-nyc-aggregations-duckdb"."rpt_daily"`. The database
-  prefix is required; without it Data Catalog / linked tables won't resolve.
-- **BigQuery** — backticked 2-part `` `dataset`.`table` `` where the `in`/`out`
-  stage is baked into the mangled dataset name (e.g. `` `out_c_nyc_aggregations_duckdb`.`rpt_daily` ``).
-
-This is the same FQN rule the `dataapp-development` skill's
-`references/storage-access.md` documents for data-app queries — the logical name
-from the semantic layer is never a substitute for it.
+Before you embed any SQL into app, transformation, or report code, confirm the
+real column names against Keboola MCP — e.g. `get_table` on the dataset's
+`tableId` — and use the metric's SQL verbatim rather than reinventing it. If
+`search_semantic_context` returns nothing relevant, there is no model to
+consult: say so and work against raw Storage. How you batch those checks is up
+to you.
 
 ## Worked example — the failure this skill prevents
 
-A user asked Kai to build a dashboard **from the semantic layer** over
-`out.c-nyc-aggregations-duckdb.rpt_*` tables. Kai read the semantic context and
-wrote the dashboard SQL using the **semantic-model field names** directly, never
-calling `get_table` to check the physical schema. Those field names did not match
-the physical columns of the `rpt_*` tables, so every query failed — the dashboard
-rendered empty even though the container was "running", and Kai reported success
-without verifying.
+A user asked Kai to build a dashboard from the semantic layer over
+`out.c-nyc-aggregations-duckdb.rpt_*` tables. Kai read the semantic context but
+wrote the dashboard SQL from the **semantic display names**, never confirming
+the physical columns. They didn't match the `rpt_*` schema, so every query
+failed: the dashboard rendered empty even though the container was "running",
+and Kai reported success without verifying.
 
-What should have happened:
+What grounds it instead:
 
 ```text
 search_semantic_context(patterns=["nyc trips", "daily revenue"])
-  → metric "daily_revenue", dataset backed by out.c-nyc-aggregations-duckdb
-get_semantic_context(...)               → metric SQL + dataset identifier + joins
-get_buckets / get_tables                → out.c-nyc-aggregations-duckdb → rpt_daily
+  → metric "daily_revenue", dataset with tableId out.c-nyc-aggregations-duckdb.rpt_daily
+get_semantic_context(...)  → metric SQL + dataset tableId + fqn (the physical mapping)
 get_table(table_id="out.c-nyc-aggregations-duckdb.rpt_daily")
-  → real columns: pickup_date, fare_total, trip_count  (NOT the semantic labels)
-  → fully_qualified_name for the query
-query_data('SELECT "pickup_date","fare_total" FROM "<DB>"."out.c-nyc-aggregations-duckdb"."rpt_daily" LIMIT 1')
-  → confirms table + columns + quoting before any dashboard code is written
+  → real columns: pickup_date, fare_total, trip_count  (NOT the display labels)
 ```
 
-The logical field the user thinks in ("revenue") maps to a physical column
-(`fare_total`) that you can only know by resolving it. Resolve first, query
-second.
+The label the user thinks in ("revenue") is the physical column `fare_total`;
+the semantic definition tells you that — read it instead of guessing.
 
 ## Related
 
-- `dataapp-development` skill — full app lifecycle; its `references/dev-workflow.md`
-  covers the validate-first loop and `references/storage-access.md` covers FQN
-  quoting per backend. Load this skill alongside it when the data source is a
-  semantic model.
+- `dataapp-development` skill — full app lifecycle; its
+  `references/storage-access.md` covers FQN quoting per backend and
+  `references/dev-workflow.md` covers the validate-first loop. Load this skill
+  alongside it when the data source is a semantic model.

--- a/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
+++ b/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: semantic-layer-usage
+description: Use when building an app, query, report, or transformation from a Keboola semantic layer / semantic model, or right after a semantic-context tool returns. The semantic layer is a LOGICAL model — its entity/metric/field names are NOT guaranteed to match physical table/column identifiers. Resolve each logical object to its physical Storage identifier and confirm real columns before writing any SQL.
+---
+
+# Using the Keboola semantic layer safely
+
+The semantic layer is a **logical model**. It describes metrics, entities, and
+fields in business terms and stores the *definition* of a calculation (its SQL,
+the dataset it belongs to, the join paths between datasets). It is **not** a
+guarantee about physical Storage naming: a semantic field called `total_revenue`
+or an entity called `Trips` will frequently **not** exist under that name as a
+physical column or table. The mapping between logical and physical is exactly
+what you must resolve — never assume it.
+
+Trusting logical names as if they were physical identifiers is the single most
+common way a semantic-layer-backed app ships broken: the SQL references columns
+that don't exist, every query errors or returns empty, and the app renders a
+blank or error screen.
+
+## Mandatory verification loop — before writing ANY SQL/query
+
+Do this for **every** logical object you plan to touch. Do not skip it because
+the names "look obvious".
+
+1. **Read the semantic definition.** `mcp__keboola__search_semantic_context` to
+   find the relevant metric/entity/dataset, then `mcp__keboola__get_semantic_context`
+   to read its SQL, the dataset's identifier, and join paths. Use the metric's
+   calculation **verbatim** — don't reinvent it.
+2. **Resolve to physical Storage identifiers.** Map each logical dataset/entity
+   to a real bucket + table with `mcp__keboola__get_buckets` → `mcp__keboola__get_tables`,
+   then `mcp__keboola__get_table(table_id=...)` for the chosen table. `get_table`
+   returns the **exact column names** (with case), data types, and the
+   `fully_qualified_name` / `fqn` to use in queries.
+3. **Confirm column names.** Match every field the semantic definition references
+   to a real column from `get_table`. If a semantic field has no obvious physical
+   column, it is derived — read the semantic SQL to see how it's computed; do not
+   guess a column name.
+4. **Probe before committing.** Run a cheap `mcp__keboola__query_data` probe —
+   `SELECT <cols> FROM <fqn> LIMIT 1` — against the resolved physical identifiers
+   to prove the table, columns, and quoting are correct **before** you write them
+   into app, transformation, or report code.
+
+Only after all four steps write the real query. If the project exposes
+`mcp__keboola__validate_semantic_query`, run it too — it catches mismatches
+against the semantic model before the SQL is embedded.
+
+## Use fully-qualified physical identifiers, exactly as returned
+
+Write queries with the exact identifier string from `get_table`, never a
+hand-derived one:
+
+- **Snowflake** — full 3-part FQN with double quotes:
+  `"KBC_REGION_PROJID"."out.c-nyc-aggregations-duckdb"."rpt_daily"`. The database
+  prefix is required; without it Data Catalog / linked tables won't resolve.
+- **BigQuery** — backticked 2-part `` `dataset`.`table` `` where the `in`/`out`
+  stage is baked into the mangled dataset name (e.g. `` `out_c_nyc_aggregations_duckdb`.`rpt_daily` ``).
+
+This is the same FQN rule the `dataapp-development` skill's
+`references/storage-access.md` documents for data-app queries — the logical name
+from the semantic layer is never a substitute for it.
+
+## Worked example — the failure this skill prevents
+
+A user asked Kai to build a dashboard **from the semantic layer** over
+`out.c-nyc-aggregations-duckdb.rpt_*` tables. Kai read the semantic context and
+wrote the dashboard SQL using the **semantic-model field names** directly, never
+calling `get_table` to check the physical schema. Those field names did not match
+the physical columns of the `rpt_*` tables, so every query failed — the dashboard
+rendered empty even though the container was "running", and Kai reported success
+without verifying.
+
+What should have happened:
+
+```text
+search_semantic_context(patterns=["nyc trips", "daily revenue"])
+  → metric "daily_revenue", dataset backed by out.c-nyc-aggregations-duckdb
+get_semantic_context(...)               → metric SQL + dataset identifier + joins
+get_buckets / get_tables                → out.c-nyc-aggregations-duckdb → rpt_daily
+get_table(table_id="out.c-nyc-aggregations-duckdb.rpt_daily")
+  → real columns: pickup_date, fare_total, trip_count  (NOT the semantic labels)
+  → fully_qualified_name for the query
+query_data('SELECT "pickup_date","fare_total" FROM "<DB>"."out.c-nyc-aggregations-duckdb"."rpt_daily" LIMIT 1')
+  → confirms table + columns + quoting before any dashboard code is written
+```
+
+The logical field the user thinks in ("revenue") maps to a physical column
+(`fare_total`) that you can only know by resolving it. Resolve first, query
+second.
+
+## Related
+
+- `dataapp-development` skill — full app lifecycle; its `references/dev-workflow.md`
+  covers the validate-first loop and `references/storage-access.md` covers FQN
+  quoting per backend. Load this skill alongside it when the data source is a
+  semantic model.

--- a/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
+++ b/plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md
@@ -23,25 +23,35 @@ blank or error screen.
 Do this for **every** logical object you plan to touch. Do not skip it because
 the names "look obvious".
 
-1. **Read the semantic definition.** `mcp__keboola__search_semantic_context` to
-   find the relevant metric/entity/dataset, then `mcp__keboola__get_semantic_context`
-   to read its SQL, the dataset's identifier, and join paths. Use the metric's
-   calculation **verbatim** — don't reinvent it.
+**Step 1 applies only when a semantic layer/model is present. Steps 2–4 are the
+floor and always apply** — whether you started from a semantic model, a bare
+Storage table, or a user's business-language request. If no semantic model
+exists (or none matches the request), say so and go straight to steps 2–4
+against the raw tables.
+
+1. **(If a semantic model is available) Read the semantic definition.**
+   `mcp__keboola__search_semantic_context` to find the relevant
+   metric/entity/dataset, then `mcp__keboola__get_semantic_context` to read its
+   SQL, the dataset's identifier, and join paths. Use the metric's calculation
+   **verbatim** — don't reinvent it. If nothing relevant is returned, treat the
+   source as raw Storage and continue with steps 2–4.
 2. **Resolve to physical Storage identifiers.** Map each logical dataset/entity
-   to a real bucket + table with `mcp__keboola__get_buckets` → `mcp__keboola__get_tables`,
-   then `mcp__keboola__get_table(table_id=...)` for the chosen table. `get_table`
+   (or the user's described table) to a real bucket + table with
+   `mcp__keboola__get_buckets` → `mcp__keboola__get_tables`, then
+   `mcp__keboola__get_table(table_id=...)` for the chosen table. `get_table`
    returns the **exact column names** (with case), data types, and the
    `fully_qualified_name` / `fqn` to use in queries.
-3. **Confirm column names.** Match every field the semantic definition references
-   to a real column from `get_table`. If a semantic field has no obvious physical
-   column, it is derived — read the semantic SQL to see how it's computed; do not
-   guess a column name.
+3. **Confirm column names.** Match every field you plan to select to a real
+   column from `get_table`. If a semantic field has no obvious physical column,
+   it is derived — read the semantic SQL to see how it's computed; do not guess
+   a column name.
 4. **Probe before committing.** Run a cheap `mcp__keboola__query_data` probe —
    `SELECT <cols> FROM <fqn> LIMIT 1` — against the resolved physical identifiers
    to prove the table, columns, and quoting are correct **before** you write them
    into app, transformation, or report code.
 
-Only after all four steps write the real query. If the project exposes
+Write the real query only after the applicable steps pass. When you did start
+from a semantic model and the project exposes
 `mcp__keboola__validate_semantic_query`, run it too — it catches mismatches
 against the semantic model before the SQL is embedded.
 


### PR DESCRIPTION
## Summary

Adds a new `semantic-layer-usage` skill to the `dataapp-developer` plugin ([AI-3520](https://linear.app/keboola/issue/AI-3520), part of AI-3518 / SUPPORT-16901).

**Why:** In SUPPORT-16901 Kai built a dashboard "from the semantic layer" and wrote the SQL from the *semantic display names* — never confirming the physical columns of the `out.c-nyc-aggregations-duckdb.rpt_*` tables. The names didn't match, every query failed, and the dashboard rendered empty even though the container was "running". The skill encodes the one fix that the MCP system prompt's Semantic Layer section doesn't already spell out.

**What the skill says (now ~55 lines):**
- The semantic layer *already carries* the physical mapping — a `semantic-dataset` returns `tableId`/`fqn`, a `semantic-metric` returns its SQL. The business-facing display names are labels, not physical columns.
- **One rule:** before embedding any SQL, confirm the real columns via Keboola MCP (e.g. `get_table` on the dataset's `tableId`) and use the metric SQL verbatim. How you batch that is up to the model.
- **Discovery/degradation:** `search_semantic_context` is the detector — matches → consult the model; nothing relevant → say so and work against raw Storage.
- A worked example modelled on the SUPPORT-16901 failure.

**Files**
```
plugins/dataapp-developer/skills/semantic-layer-usage/SKILL.md   (new)
plugins/dataapp-developer/.claude-plugin/plugin.json             1.3.0 → 1.4.0
.claude-plugin/marketplace.json  (dataapp-developer entry)       1.3.0 → 1.4.0
plugins/dataapp-developer/README.md                              new skill + version + structure
README.md                                                        dataapp-developer feature line
```

`claude plugin validate .` passes.

### Review updates
- **6d6f19f** — per @davidesner, made the loop degrade gracefully (step 1 gated on a model being present, steps 2–4 the floor).
- **Latest commit** — per @tomasfejfar, substantially trimmed: dropped the prescriptive 4-step loop and the FQN section (both duplicated the MCP system prompt, and the FQN part conflicted with its input-mapping preference), added the discovery line, and corrected the premise. Verified against the MCP server source that `semantic-dataset` carries `tableId`/`fqn` and `semantic-metric` carries `sql` — so the layer *does* provide the mapping; the skill now says "use it and confirm the columns," not "re-derive it." Net effect: 106 → ~55 lines.

## Open question from the ticket — resolved
Does `get_semantic_context` already return the physical mapping? **Yes.** In `keboola/mcp-server`, `SemanticDatasetCompact`/`SemanticUsedDataset` expose `tableId` + `fqn` and `SemanticUsedMetric` exposes `sql`. So the mapping is provided by the layer; the residual risk (and the SUPPORT-16901 failure) is the agent writing SQL from the display labels instead of confirming the real columns — which is what the trimmed skill targets.

## Note on where this lives / next step for Kai
Per Jordan's direction this lives in `keboola/ai-kit` (not the ticket's original `keboola/ui` `packages/kai-agent-sandbox/skills/`). Heads-up unchanged: `kai-agent-sandbox`'s `scripts/vendor-external-skills.ts` currently vendors only the `dataapp-development` subpath, so this standalone skill won't auto-ship into Kai's sandbox until that script also pulls `semantic-layer-usage` (or the guidance is folded into `dataapp-development`). Left out of scope here as requested — candidate follow-up, alongside the eventual consolidation with the `sl-toolkit`/sl-builder plugin.

## Release Notes
**Justification, description**

Documentation/skill-only change: teaches agents (and Kai) to confirm a semantic model's physical columns before writing SQL, preventing empty/broken semantic-layer-backed apps (SUPPORT-16901).

**Plans for Customer Communication**

N/A

**Impact Analysis**

N/A — no runtime code; adds a Markdown skill and bumps plugin/marketplace versions.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/8bdc15f5a0fa4109a4c814dd9a30bc94
Requested by: @jordanrburger