### PR TITLE
docs(component-developer): document options.encryption_hint for JSON editor fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "component-developer",
       "description": "Comprehensive toolkit for building Keboola Python components with Agent Skills format",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "source": "./plugins/component-developer",
       "category": "development"
     },

--- a/plugins/component-developer/.claude-plugin/plugin.json
+++ b/plugins/component-developer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "component-developer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Comprehensive toolkit for building Keboola Python components with Agent Skills format. Includes specialized skills for component development, UI/schema design, unified testing (datadir, unit, VCR), debugging, consolidated code quality and backward compatibility review, and platform context knowledge.",
   "author": {
     "name": "Keboola :(){:|:&};: s.r.o.",

--- a/plugins/component-developer/skills/build-component-ui/references/ui-elements.md
+++ b/plugins/component-developer/skills/build-component-ui/references/ui-elements.md
@@ -643,21 +643,7 @@ Use with `format: "editor"` and `options.editor.mode`.
 > - Default mode is `application/json` when `options.editor.mode` is not specified
 > - JSON mode (`application/json`) supports field encryption — use `"type": "object"` (not `"string"`) so the UI can store an encrypted JSON object
 > - All other modes use `"type": "string"`
-> - A JSON-mode editor renders a note saying `#`-prefixed properties will be encrypted on save. Set `options.encryption_hint: false` when the field does not hold Keboola configuration (a vendor query filter, a request payload template), where encrypting a key would only hand the component ciphertext it cannot use. The option affects the note only — encryption behaviour is unchanged.
->
-> ```json
-> {
->   "filters": {
->     "type": "object",
->     "title": "Filters",
->     "format": "editor",
->     "options": {
->       "editor": { "mode": "application/json" },
->       "encryption_hint": false
->     }
->   }
-> }
-> ```
+> - JSON mode renders a note about `#`-prefixed properties being encrypted; hide it with `options.encryption_hint: false` when the field is not Keboola configuration (a vendor filter tree, a payload template)
 
 ### Available Modes
 

--- a/plugins/component-developer/skills/build-component-ui/references/ui-elements.md
+++ b/plugins/component-developer/skills/build-component-ui/references/ui-elements.md
@@ -369,6 +369,7 @@ Options control field behavior and appearance.
 | `editor.placeholder` | string | Placeholder text for empty editor |
 | `editor.autofocus` | boolean | Auto-focus editor on load |
 | `editor.lint` | boolean | Enable linting (for JSON mode) |
+| `encryption_hint` | boolean | Set to `false` to hide the "properties prefixed with `#` will be encrypted" note under a JSON-mode editor |
 | `only_keys` | boolean | SSH form: show only keys (not full tunnel) |
 
 ### Behavior Options
@@ -642,6 +643,21 @@ Use with `format: "editor"` and `options.editor.mode`.
 > - Default mode is `application/json` when `options.editor.mode` is not specified
 > - JSON mode (`application/json`) supports field encryption — use `"type": "object"` (not `"string"`) so the UI can store an encrypted JSON object
 > - All other modes use `"type": "string"`
+> - A JSON-mode editor renders a note saying `#`-prefixed properties will be encrypted on save. Set `options.encryption_hint: false` when the field does not hold Keboola configuration (a vendor query filter, a request payload template), where encrypting a key would only hand the component ciphertext it cannot use. The option affects the note only — encryption behaviour is unchanged.
+>
+> ```json
+> {
+>   "filters": {
+>     "type": "object",
+>     "title": "Filters",
+>     "format": "editor",
+>     "options": {
+>       "editor": { "mode": "application/json" },
+>       "encryption_hint": false
+>     }
+>   }
+> }
+> ```
 
 ### Available Modes
 


### PR DESCRIPTION
## Summary

Documents `options.encryption_hint`, the new component-schema option shipped in keboola/ui#7627 (Linear UT-4836), in the `build-component-ui` UI-elements reference so Component Factory authors find the opt-out instead of reporting the hint as a component bug.

A `format: editor` field in `application/json` mode stores the *parsed* JSON, so a `#`-prefixed key inside it really is encrypted on save — regardless of the declared type. Where the JSON is not Keboola configuration (a vendor filter tree, a payload template), the note advertises an action the component cannot use. `"options": { "encryption_hint": false }` hides the note; encryption behaviour is unchanged.

- `references/ui-elements.md` — one row in Editor Options, one bullet under Code Editor Modes.
- Patch version bump of `component-developer` in the plugin manifest and marketplace.

Platform-side docs (Supported Options table): keboola/developers-docs#409


Link to Devin session: https://app.devin.ai/sessions/bad65a351c774d9d9d23e7684c7c68ac
Requested by: @natocTo