### PR TITLE
fix(dataapp-developer): pin templates to patched query-service SDKs

### DIFF
--- a/plugins/dataapp-developer/skills/dataapp-development/TODO.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/TODO.md
@@ -36,7 +36,7 @@ Sections we know are incomplete because the underlying pattern isn't firm yet. M
 
 - **`storage-access.md` §Data access management — PLACEHOLDER.** Per-user / row-level data access control. No documented pattern; internal apps diverge. Cross-referenced from `authentication.md`.
 - **`python-js-apps.md` §Deployment via MCP — PLACEHOLDER.** Fill in once `modify_streamlit_data_app` covers Python/JS.
-- **SQL helpers in Query Service SDKs.** Once `SQL.literal()` / `SQL.ident()` / `sql.format()` ship in `keboola-query-service` (Py) and `@keboola/query-service` (JS), replace the manual sanitization patterns in `storage-access.md` §SQL injection with SDK-driven examples.
+- **SQL helpers in Query Service SDKs.** Once `SQL.literal()` / `SQL.ident()` / `sql.format()` ship in `keboola-query-service` (Py) and `@keboola/api-client`'s `queryService` client (JS), replace the manual sanitization patterns in `storage-access.md` §SQL injection with SDK-driven examples.
 - **Two Max Ottomansky suggestions from AI-3147 not yet picked up:**
   - Prebuilt JS apps — committing `dist/` to skip `npm install` / build on cold start. Worth a short subsection in `python-js-apps.md` once the deployment story is settled.
   - `KAI_TOKEN` secret workaround for embedding Kai chat without manual user token entry. Belongs in `kai-integration.md` once the contract with `kai-client` is firm.

--- a/plugins/dataapp-developer/skills/dataapp-development/references/duckdb-caching.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/duckdb-caching.md
@@ -233,6 +233,19 @@ Use DuckDB when:
 
 You can combine both: DuckDB for the shared cache + `@st.cache_data` for derived per-session aggregations.
 
+## Verifying the cache is complete
+
+A cache silently holding a fraction of the table is worse than no cache — the dashboard stays fast and green while every KPI built on it is wrong. After each `refresh()`, compare `rowCount`/`_row_count` against the table's real row count from `get_table`'s `rows_count` field (or `SELECT COUNT(*)` against the source), and log/alert on a mismatch instead of trusting the pull silently succeeded:
+
+```javascript
+const expected = await getExpectedRowCount(); // e.g. mcp get_table().rows_count
+if (rowCount !== expected) {
+  console.error(`[duck] cache mismatch: pulled ${rowCount}, source has ${expected}`);
+}
+```
+
+This catches exactly the failure mode of pulling through a truncating query path (e.g. an unpatched SDK, or a hand-rolled query capped at a default page size) — the pull "succeeds" with a plausible-looking row count that's actually a silent truncation.
+
 ## Template
 
 Runnable starters live at:

--- a/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
@@ -76,7 +76,7 @@ See `references/kai-integration.md` for the embed patterns.
 
 Python SDK: https://github.com/keboola/query-service-api-python-sdk
 
-JS/TS: `@keboola/api-client`'s `queryService` client (https://github.com/keboola/ui, `packages/api-client`) — the formerly-standalone `query-service-api-js-sdk` repo is retired; its `executeQuery`/pagination behavior now lives here.
+JS/TS: `@keboola/api-client`'s `queryService` client + `queryService` SDK (https://github.com/keboola/ui, `packages/api-client`) — the formerly-standalone `query-service-api-js-sdk` repo is retired; `executeQuery`/`waitForJob`/pagination now live in `createQueryServiceSdk` (`@keboola/api-client/sdk/queryService`), composed on top of the plain `queryService` client (`@keboola/api-client/queryService`).
 
 Used when the app writes back to Storage tables via the Query Service (Snowflake projects with the **Storage Access** feature enabled). Provides authenticated `execute_query` against a permission-scoped workspace.
 

--- a/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/glossary.md
@@ -76,11 +76,11 @@ See `references/kai-integration.md` for the embed patterns.
 
 Python SDK: https://github.com/keboola/query-service-api-python-sdk
 
-JS/TS SDK: https://github.com/keboola/query-service-api-js-sdk
+JS/TS: `@keboola/api-client`'s `queryService` client (https://github.com/keboola/ui, `packages/api-client`) — the formerly-standalone `query-service-api-js-sdk` repo is retired; its `executeQuery`/pagination behavior now lives here.
 
 Used when the app writes back to Storage tables via the Query Service (Snowflake projects with the **Storage Access** feature enabled). Provides authenticated `execute_query` against a permission-scoped workspace.
 
-First-class SQL helpers (`SQL.literal()`, `SQL.ident()`, `sql.format()`) are in development in both SDKs. Until released, use the manual sanitization pattern shown in `references/storage-access.md` (allowlists for strings, type-coercion for numbers).
+First-class SQL helpers (`SQL.literal()`, `SQL.ident()`, `sql.format()`) are in development for the Python SDK. Until released, use the manual sanitization pattern shown in `references/storage-access.md` (allowlists for strings, type-coercion for numbers).
 
 Install:
 
@@ -89,7 +89,7 @@ Install:
 uv add keboola-query-service
 
 # JS
-npm install @keboola/query-service
+npm install @keboola/api-client
 ```
 
 ### keboola-streamlit (helper utilities)

--- a/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
@@ -121,7 +121,7 @@ Use this when:
 Two paths to call the workspace:
 
 - **MCP-injected `query_data`** — when `modify_streamlit_data_app` is involved, a `query_data(sql) -> pd.DataFrame` function is dropped into the source code via the `{QUERY_DATA_FUNCTION}` placeholder. Use it as-is; don't roll your own.
-- **Query Service via the official SDK** — for Python/JS apps without MCP injection, call the Query Service API (`https://query.<stack>.keboola.com/api/v1/...`) using `keboola-query-service` (Python) or `@keboola/query-service` (JS/TS). The SDK handles submit + poll + paginate; you call `executeQuery({ branchId, workspaceId, statements })` and get back columns + rows.
+- **Query Service via the official SDK** — for Python/JS apps without MCP injection, call the Query Service API (`https://query.<stack>.keboola.com/api/v1/...`) using `keboola-query-service` (Python) or `@keboola/api-client`'s `queryService` client (JS/TS). The SDK handles submit + poll + paginate; you call `executeQuery(...)` and get back columns + rows.
 
 **On Snowflake, do NOT post to `/v2/storage/branch/<b>/workspaces/<w>/query`.** That older Storage API workspace-query endpoint returns `workspace.workspaceNotFound` 404s on Snowflake projects — use the Query Service instead. On BigQuery it does work and is a valid alternative (see "Alternative: Storage API workspace-query endpoint" below), but default to the Query Service on both backends.
 
@@ -172,21 +172,28 @@ cols = [c.name for c in result.columns]
 rows = [dict(zip(cols, row)) for row in result.data]
 ```
 
-JS/TS (`@keboola/query-service`):
+JS/TS (`@keboola/api-client`'s `queryService` client):
 
 ```javascript
-import { Client } from '@keboola/query-service';
+import { createQueryServiceClient } from '@keboola/api-client/queryService';
 
 const baseUrl =
   process.env.QUERY_SERVICE_URL ||
   process.env.KBC_URL.replace('://connection.', '://query.');
-const client = new Client({ baseUrl, token: process.env.KBC_TOKEN });
-
-const [result] = await client.executeQuery({
-  branchId: process.env.BRANCH_ID,           // numeric
-  workspaceId: process.env.WORKSPACE_ID,
-  statements: ['SELECT * FROM "KBC_REGION_PROJID"."in.c-main"."customers" LIMIT 100'],
+const client = createQueryServiceClient({
+  baseUrl,
+  auth: { type: 'sapi-token', token: process.env.KBC_TOKEN },
+  middlewares: [],
 });
+
+const [result] = await client.executeQuery(
+  process.env.BRANCH_ID,      // numeric
+  process.env.WORKSPACE_ID,
+  {
+    statements: ['SELECT * FROM "KBC_REGION_PROJID"."in.c-main"."customers" LIMIT 100'],
+    transactional: true,
+  },
+);
 const cols = result.columns.map((c) => c.name);
 const rows = result.data.map((row) =>
   Object.fromEntries(cols.map((name, i) => [name, row[i]])),
@@ -305,7 +312,7 @@ A few things worth noting on the BQ path that differ from Query Service:
 - **Rows arrive as objects keyed by column name**, not arrays + separate columns metadata. Iterate directly.
 - **Cell values are native types** (numbers, booleans, ISO strings for timestamps) — the string-cell coercion you do on the Query Service path is unnecessary here.
 - **No submit/poll/paginate.** The endpoint returns the full result in one synchronous response. For very large result sets, add a `LIMIT` on the SQL side; the response doesn't paginate.
-- **The skill's templates (`templates/streamlit/`, `templates/nodejs-app/`) are wired for the Query Service with Snowflake quoting.** The Query Service works on BigQuery too, so on a BigQuery project you keep the `keboola-query-service` / `@keboola/query-service` client — you only adjust the SQL (backtick quoting and mangled dataset names, see "BigQuery SQL dialect" above). Switch to this Storage API endpoint only if you specifically want it.
+- **The skill's templates (`templates/streamlit/`, `templates/nodejs-app/`) are wired for the Query Service with Snowflake quoting.** The Query Service works on BigQuery too, so on a BigQuery project you keep the `keboola-query-service` / `@keboola/api-client` `queryService` client — you only adjust the SQL (backtick quoting and mangled dataset names, see "BigQuery SQL dialect" above). Switch to this Storage API endpoint only if you specifically want it.
 
 ## Read-write direct access (Storage Access)
 
@@ -341,7 +348,7 @@ Env vars set when Storage Access is enabled:
 
 Library:
 - Python: `keboola-query-service`
-- JS/TS: `@keboola/query-service`
+- JS/TS: `@keboola/api-client`'s `queryService` client (`@keboola/api-client/queryService`)
 
 ### Wrap the SDK in a single module
 
@@ -398,20 +405,24 @@ storage = Storage()  # module-level singleton
 
 ```typescript
 import { readFileSync } from 'node:fs';
-import { Client } from '@keboola/query-service';
+import { createQueryServiceClient } from '@keboola/api-client/queryService';
 
 const branchId = process.env.BRANCH_ID!;
 const workspaceId = JSON.parse(
   readFileSync(process.env.KBC_WORKSPACE_MANIFEST_PATH!, 'utf8'),
 ).workspaceId as string;
 
-const client = new Client({
+const client = createQueryServiceClient({
   baseUrl: process.env.QUERY_SERVICE_URL!,
-  token: process.env.KBC_TOKEN!,
+  auth: { type: 'sapi-token', token: process.env.KBC_TOKEN! },
+  middlewares: [],
 });
 
 export async function select<T = Record<string, unknown>>(sql: string): Promise<T[]> {
-  const [result] = await client.executeQuery({ branchId, workspaceId, statements: [sql] });
+  const [result] = await client.executeQuery(branchId, workspaceId, {
+    statements: [sql],
+    transactional: true,
+  });
   const cols = result.columns.map((c) => c.name);
   return result.data.map((row: unknown[]) =>
     Object.fromEntries(cols.map((name, i) => [name, row[i]])) as T,
@@ -419,7 +430,7 @@ export async function select<T = Record<string, unknown>>(sql: string): Promise<
 }
 
 export async function execute(sql: string): Promise<void> {
-  await client.executeQuery({ branchId, workspaceId, statements: [sql] });
+  await client.executeQuery(branchId, workspaceId, { statements: [sql], transactional: true });
 }
 ```
 
@@ -534,7 +545,7 @@ First-class `SQL.literal()` / `SQL.ident()` / `sql.format()` helpers are in deve
 
 ## Query Service return shape — cells come back as strings
 
-Applies to the Query Service path on **both Snowflake and BigQuery** — direct RO workspace queries and Storage Access reads/writes via `keboola-query-service` / `@keboola/query-service`. On either backend, every cell comes back as a **string** regardless of SQL type. Verified on BigQuery: `INT64 42` → `"42"`, `FLOAT64 3.14` → `"3.14"`, `BOOL TRUE` → `"true"`, `NUMERIC 99.95` → `"99.95"`, `TIMESTAMP` → a string, and SQL `NULL` → `None`/`null`. The only native-typed path is the Storage API workspace endpoint (the BigQuery alternative above) — that's why its examples skip the coercion below.
+Applies to the Query Service path on **both Snowflake and BigQuery** — direct RO workspace queries and Storage Access reads/writes via `keboola-query-service` / `@keboola/api-client`'s `queryService` client. On either backend, every cell comes back as a **string** regardless of SQL type. Verified on BigQuery: `INT64 42` → `"42"`, `FLOAT64 3.14` → `"3.14"`, `BOOL TRUE` → `"true"`, `NUMERIC 99.95` → `"99.95"`, `TIMESTAMP` → a string, and SQL `NULL` → `None`/`null`. The only native-typed path is the Storage API workspace endpoint (the BigQuery alternative above) — that's why its examples skip the coercion below.
 
 `result.columns` carries the declared type so you know what to coerce, but the type names are driver-dependent: Snowflake reports lowercase internal names (`fixed`, `real`, `text`, `timestamp_ntz`), BigQuery reports uppercase (`INTEGER`, `FLOAT`, `NUMERIC`, `BOOLEAN`, `DATE`, `TIMESTAMP`).
 
@@ -556,7 +567,7 @@ df['created_at'] = pd.to_datetime(df['created_at'], errors='coerce')
 
 The DataFrame's dtype stays `object` (string) until you explicitly convert. Convert at the boundary — once, right after the query — not inside every chart.
 
-**JavaScript (when using `@keboola/query-service` directly):** zip `result.data` with `result.columns` to produce objects, and coerce numeric columns. Inspect the actual `column.type` values returned by the API for your project — they're driver-dependent (Snowflake reports lowercase internal names like `"text"`, `"fixed"`, `"real"`, `"timestamp_ntz"`; BigQuery reports uppercase `"INTEGER"`, `"FLOAT"`, `"NUMERIC"`, `"BOOLEAN"`, `"DATE"`, `"TIMESTAMP"`). Don't hand the raw `result.data` straight to the UI layer.
+**JavaScript (when using `@keboola/api-client`'s `queryService` client directly):** zip `result.data` with `result.columns` to produce objects, and coerce numeric columns. Inspect the actual `column.type` values returned by the API for your project — they're driver-dependent (Snowflake reports lowercase internal names like `"text"`, `"fixed"`, `"real"`, `"timestamp_ntz"`; BigQuery reports uppercase `"INTEGER"`, `"FLOAT"`, `"NUMERIC"`, `"BOOLEAN"`, `"DATE"`, `"TIMESTAMP"`). Don't hand the raw `result.data` straight to the UI layer.
 
 ```javascript
 function toObjects(result) {

--- a/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/storage-access.md
@@ -121,7 +121,7 @@ Use this when:
 Two paths to call the workspace:
 
 - **MCP-injected `query_data`** — when `modify_streamlit_data_app` is involved, a `query_data(sql) -> pd.DataFrame` function is dropped into the source code via the `{QUERY_DATA_FUNCTION}` placeholder. Use it as-is; don't roll your own.
-- **Query Service via the official SDK** — for Python/JS apps without MCP injection, call the Query Service API (`https://query.<stack>.keboola.com/api/v1/...`) using `keboola-query-service` (Python) or `@keboola/api-client`'s `queryService` client (JS/TS). The SDK handles submit + poll + paginate; you call `executeQuery(...)` and get back columns + rows.
+- **Query Service via the official SDK** — for Python/JS apps without MCP injection, call the Query Service API (`https://query.<stack>.keboola.com/api/v1/...`) using `keboola-query-service` (Python) or `@keboola/api-client`'s `queryService` client + `queryService` SDK (JS/TS: `createQueryServiceSdk({ queryServiceClient })`). The SDK handles submit + poll + paginate; you call `executeQuery(...)` and get back columns + rows.
 
 **On Snowflake, do NOT post to `/v2/storage/branch/<b>/workspaces/<w>/query`.** That older Storage API workspace-query endpoint returns `workspace.workspaceNotFound` 404s on Snowflake projects — use the Query Service instead. On BigQuery it does work and is a valid alternative (see "Alternative: Storage API workspace-query endpoint" below), but default to the Query Service on both backends.
 
@@ -172,21 +172,23 @@ cols = [c.name for c in result.columns]
 rows = [dict(zip(cols, row)) for row in result.data]
 ```
 
-JS/TS (`@keboola/api-client`'s `queryService` client):
+JS/TS (`@keboola/api-client`'s `queryService` client + `queryService` SDK):
 
 ```javascript
 import { createQueryServiceClient } from '@keboola/api-client/queryService';
+import { createQueryServiceSdk } from '@keboola/api-client/sdk/queryService';
 
 const baseUrl =
   process.env.QUERY_SERVICE_URL ||
   process.env.KBC_URL.replace('://connection.', '://query.');
-const client = createQueryServiceClient({
+const queryServiceClient = createQueryServiceClient({
   baseUrl,
   auth: { type: 'sapi-token', token: process.env.KBC_TOKEN },
   middlewares: [],
 });
+const sdk = createQueryServiceSdk({ queryServiceClient });
 
-const [result] = await client.executeQuery(
+const [result] = await sdk.executeQuery(
   process.env.BRANCH_ID,      // numeric
   process.env.WORKSPACE_ID,
   {
@@ -348,7 +350,7 @@ Env vars set when Storage Access is enabled:
 
 Library:
 - Python: `keboola-query-service`
-- JS/TS: `@keboola/api-client`'s `queryService` client (`@keboola/api-client/queryService`)
+- JS/TS: `@keboola/api-client`'s `queryService` client (`@keboola/api-client/queryService`) + `queryService` SDK (`@keboola/api-client/sdk/queryService`)
 
 ### Wrap the SDK in a single module
 
@@ -406,20 +408,22 @@ storage = Storage()  # module-level singleton
 ```typescript
 import { readFileSync } from 'node:fs';
 import { createQueryServiceClient } from '@keboola/api-client/queryService';
+import { createQueryServiceSdk } from '@keboola/api-client/sdk/queryService';
 
 const branchId = process.env.BRANCH_ID!;
 const workspaceId = JSON.parse(
   readFileSync(process.env.KBC_WORKSPACE_MANIFEST_PATH!, 'utf8'),
 ).workspaceId as string;
 
-const client = createQueryServiceClient({
+const queryServiceClient = createQueryServiceClient({
   baseUrl: process.env.QUERY_SERVICE_URL!,
   auth: { type: 'sapi-token', token: process.env.KBC_TOKEN! },
   middlewares: [],
 });
+const sdk = createQueryServiceSdk({ queryServiceClient });
 
 export async function select<T = Record<string, unknown>>(sql: string): Promise<T[]> {
-  const [result] = await client.executeQuery(branchId, workspaceId, {
+  const [result] = await sdk.executeQuery(branchId, workspaceId, {
     statements: [sql],
     transactional: true,
   });
@@ -430,7 +434,7 @@ export async function select<T = Record<string, unknown>>(sql: string): Promise<
 }
 
 export async function execute(sql: string): Promise<void> {
-  await client.executeQuery(branchId, workspaceId, { statements: [sql], transactional: true });
+  await sdk.executeQuery(branchId, workspaceId, { statements: [sql], transactional: true });
 }
 ```
 

--- a/plugins/dataapp-developer/skills/dataapp-development/references/troubleshooting.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/troubleshooting.md
@@ -64,7 +64,7 @@
 
 **Cause:** Calling `{KBC_URL}/v2/storage/branch/<b>/workspaces/<w>/query` on a Snowflake project. That endpoint serves BigQuery workspaces, not Snowflake ones.
 
-**Fix:** Switch to the Query Service via `keboola-query-service` / `@keboola/query-service` — the preferred path on both backends. See [storage-access.md](storage-access.md) §Direct RO workspace queries.
+**Fix:** Switch to the Query Service via `keboola-query-service` (Python) / `@keboola/api-client`'s `queryService` client (JS) — the preferred path on both backends. See [storage-access.md](storage-access.md) §Direct RO workspace queries.
 
 ## Workspace ID value has `WORKSPACE_<id>` prefix
 

--- a/plugins/dataapp-developer/skills/dataapp-development/references/troubleshooting.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/troubleshooting.md
@@ -64,7 +64,7 @@
 
 **Cause:** Calling `{KBC_URL}/v2/storage/branch/<b>/workspaces/<w>/query` on a Snowflake project. That endpoint serves BigQuery workspaces, not Snowflake ones.
 
-**Fix:** Switch to the Query Service via `keboola-query-service` (Python) / `@keboola/api-client`'s `queryService` client (JS) — the preferred path on both backends. See [storage-access.md](storage-access.md) §Direct RO workspace queries.
+**Fix:** Switch to the Query Service via `keboola-query-service` (Python) / `@keboola/api-client`'s `queryService` client + SDK (JS) — the preferred path on both backends. See [storage-access.md](storage-access.md) §Direct RO workspace queries.
 
 ## Workspace ID value has `WORKSPACE_<id>` prefix
 

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/api/keboola-client.js
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/api/keboola-client.js
@@ -1,11 +1,12 @@
 // Centralized Keboola Query Service client for the Node.js data app.
 //
-// Uses @keboola/query-service which targets https://query.<stack>.keboola.com/api/v1/...
+// Uses @keboola/api-client's queryService client, which targets
+// https://query.<stack>.keboola.com/api/v1/...
 // Do NOT POST to /v2/storage/.../workspaces/<id>/query — that's the legacy Storage API
 // workspace-query endpoint, it 404s on most Snowflake projects.
 
 import { readFileSync, existsSync } from 'node:fs';
-import { Client } from '@keboola/query-service';
+import { createQueryServiceClient } from '@keboola/api-client/queryService';
 
 function normalizeWorkspaceId(raw) {
   if (!raw) return null;
@@ -72,7 +73,11 @@ function getClient() {
         'Ask the user to populate .env or .env.local.',
     );
   }
-  _client = new Client({ baseUrl: queryServiceUrl, token });
+  _client = createQueryServiceClient({
+    baseUrl: queryServiceUrl,
+    auth: { type: 'sapi-token', token },
+    middlewares: [],
+  });
   return _client;
 }
 
@@ -87,10 +92,9 @@ export async function runQuery(sql) {
   if (!workspace) missing.push('WORKSPACE_ID (or KBC_WORKSPACE_MANIFEST_PATH)');
   if (missing.length > 0) throw new Error(`Missing env vars: ${missing.join(', ')}`);
 
-  const [result] = await getClient().executeQuery({
-    branchId: String(branch),
-    workspaceId: String(workspace),
+  const [result] = await getClient().executeQuery(String(branch), String(workspace), {
     statements: [sql],
+    transactional: true,
   });
   const cols = result.columns.map((c) => c.name.toLowerCase());
   return result.data.map((row) => {

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/api/keboola-client.js
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/api/keboola-client.js
@@ -1,12 +1,13 @@
 // Centralized Keboola Query Service client for the Node.js data app.
 //
-// Uses @keboola/api-client's queryService client, which targets
+// Uses @keboola/api-client's queryService client + queryService SDK, which target
 // https://query.<stack>.keboola.com/api/v1/...
 // Do NOT POST to /v2/storage/.../workspaces/<id>/query — that's the legacy Storage API
 // workspace-query endpoint, it 404s on most Snowflake projects.
 
 import { readFileSync, existsSync } from 'node:fs';
 import { createQueryServiceClient } from '@keboola/api-client/queryService';
+import { createQueryServiceSdk } from '@keboola/api-client/sdk/queryService';
 
 function normalizeWorkspaceId(raw) {
   if (!raw) return null;
@@ -63,9 +64,9 @@ export function resolveKeboolaEnv() {
   };
 }
 
-let _client = null;
-function getClient() {
-  if (_client) return _client;
+let _sdk = null;
+function getSdk() {
+  if (_sdk) return _sdk;
   const { queryServiceUrl, token } = resolveKeboolaEnv();
   if (!queryServiceUrl || !token) {
     throw new Error(
@@ -73,12 +74,13 @@ function getClient() {
         'Ask the user to populate .env or .env.local.',
     );
   }
-  _client = createQueryServiceClient({
+  const queryServiceClient = createQueryServiceClient({
     baseUrl: queryServiceUrl,
     auth: { type: 'sapi-token', token },
     middlewares: [],
   });
-  return _client;
+  _sdk = createQueryServiceSdk({ queryServiceClient });
+  return _sdk;
 }
 
 // Returns rows as objects { column_name: value }, lowercased keys, with naive numeric
@@ -92,10 +94,18 @@ export async function runQuery(sql) {
   if (!workspace) missing.push('WORKSPACE_ID (or KBC_WORKSPACE_MANIFEST_PATH)');
   if (missing.length > 0) throw new Error(`Missing env vars: ${missing.join(', ')}`);
 
-  const [result] = await getClient().executeQuery(String(branch), String(workspace), {
+  const [result] = await getSdk().executeQuery(String(branch), String(workspace), {
     statements: [sql],
     transactional: true,
   });
+  // Belt-and-braces: executeQuery auto-paginates, but if a future SDK regression silently
+  // truncated again, this turns it into a loud failure instead of a quietly-wrong dashboard.
+  if (result.numberOfRows !== undefined && result.data.length !== result.numberOfRows) {
+    throw new Error(
+      `Query returned ${result.data.length} rows but numberOfRows is ${result.numberOfRows} — ` +
+        'results were truncated.',
+    );
+  }
   const cols = result.columns.map((c) => c.name.toLowerCase());
   return result.data.map((row) => {
     const out = {};

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
@@ -9,7 +9,7 @@
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --watch server.js"
   },
   "dependencies": {
-    "@keboola/query-service": "^0.1.0",
+    "@keboola/query-service": "^0.1.5",
     "express": "^4.21.2"
   },
   "engines": {

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
@@ -9,7 +9,7 @@
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --watch server.js"
   },
   "dependencies": {
-    "@keboola/query-service": "^0.1.5",
+    "@keboola/api-client": "^26.0.0",
     "express": "^4.21.2"
   },
   "engines": {

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/nodejs-app/package.json
@@ -9,7 +9,7 @@
     "dev": "node --env-file-if-exists=.env --env-file-if-exists=.env.local --watch server.js"
   },
   "dependencies": {
-    "@keboola/api-client": "^26.0.0",
+    "@keboola/api-client": "^27.0.0",
     "express": "^4.21.2"
   },
   "engines": {

--- a/plugins/dataapp-developer/skills/dataapp-development/templates/streamlit/pyproject.toml
+++ b/plugins/dataapp-developer/skills/dataapp-development/templates/streamlit/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "streamlit~=1.45.0",
     "pandas~=2.2.0",
     "plotly~=6.0.0",
-    "keboola-query-service>=0.2.0",
+    "keboola-query-service>=0.3.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
The `@keboola/query-service` JS SDK is being retired in favor of `@keboola/api-client`'s `queryService` client + `queryService` SDK (`createQueryServiceSdk`, keboola/ui#8059), which now carries the same `executeQuery`/auto-pagination fix. This repoints every JS/TS reference in the `dataapp-developer` skill accordingly:
- `templates/nodejs-app/package.json` + `api/keboola-client.js`: constructs `createQueryServiceClient(...)` then `createQueryServiceSdk({ queryServiceClient })`, calls `executeQuery` on the SDK. Also asserts `data.length === numberOfRows` after `executeQuery` as a loud-failure guard (per @MiroCillik's suggestion) — belt-and-braces in case a future SDK regression silently truncates again.
- `references/storage-access.md`, `troubleshooting.md`, `TODO.md`, `glossary.md`: every JS/TS example and mention updated to the client+SDK construction.

The Python side (`keboola-query-service`) is untouched — its own fix (keboola/query-service-api-python-sdk#9, released as v0.3.0) already ships independently and is installable today.

Also (from the original commit): bumped `templates/streamlit/pyproject.toml`'s `keboola-query-service` floor to `>=0.3.0`, and added a cache-completeness check to `duckdb-caching.md`.

Linear: [AI-3752](https://linear.app/keboola/issue/AI-3752)

## Test plan
- [x] `@keboola/api-client`'s `queryService` SDK (keboola/ui#8059) is tested there — type-check, lint, 906 tests including 10 for the SDK, all green.
- [x] Grepped this repo for any remaining `@keboola/query-service` / `query-service-api-js-sdk` / stale `client.executeQuery(...)` references — none left
- [x] `@keboola/api-client@27.0.0` is published (`npm view @keboola/api-client dist-tags` → `latest: 27.0.0`). Installed it directly and confirmed `/queryService` exports `createQueryServiceClient` and `/sdk/queryService` exports `createQueryServiceSdk`, matching the template's imports. Read the built SDK source: `executeQuery` creates the job, waits for completion, then `fetchAllResultPages` loops on `offset`/`pageSize` against `getQueryResults` until `data.length >= numberOfRows` — the auto-pagination claim in the docs holds, and `numberOfRows` is the true total (not the page count), so the template's truncation guard is non-vacuous.
- [x] Still open: an empirical run against a real >500-row table (e.g. @MiroCillik's `in.c-dbt-beers.beers`, 2412 rows) hasn't been done against v27 specifically — no KBC credentials in this environment. Static verification above is strong but not a substitute for that live check.
