### PR TITLE
fix(AI-3750): stop pointing kbagent installers at the wrong CLI

### DIFF
--- a/plugins/keboola-git/README.md
+++ b/plugins/keboola-git/README.md
@@ -34,7 +34,7 @@ Bidirectional copy of a data app's source between GitHub and Keboola git.
 
 ## ✅ Prerequisites
 
-- **kbagent** installed and on `PATH` (`kbagent --version`). See the `keboola-cli` plugin / kbagent docs.
+- **kbagent** installed and on `PATH` (`kbagent --version`). Install: `https://github.com/keboola/cli#install` (`/plugin marketplace add keboola/cli` then `/plugin install kbagent@keboola-agent-cli` for the Claude Code skill). Not the `keboola-cli` plugin in this repo — that one wraps the older `kbc` CLI (`developers.keboola.com/cli`), a different tool.
 - Project registered: `kbagent --json project add --project <alias> --stack <stack-url> --storage-token "$KBC_TOKEN"`.
 - `export KBAGENT_CONVERSATION_ID=$(uuidgen)` once per shell session.
 - A **manage token** in the environment for `data-app logs` / `password` / `delete` (used with `--allow-env-manage-token`).
@@ -49,4 +49,3 @@ Bidirectional copy of a data app's source between GitHub and Keboola git.
 ## Related
 
 - [`dataapp-developer`](../dataapp-developer) — `dataapp-deployment` skill for `keboola-config/` (setup.sh, nginx, supervisord) and `dataapp-dev` for Streamlit.
-- [`keboola-cli`](../keboola-cli) — broader kbagent project management and review.

--- a/plugins/keboola-git/skills/keboola-git/SKILL.md
+++ b/plugins/keboola-git/skills/keboola-git/SKILL.md
@@ -25,7 +25,7 @@ All `git` and `kbagent` operations run from the **user's project root** or a **s
 
 ## Prerequisites
 
-1. **kbagent installed** and on `PATH` (`kbagent --version`). Install: see the kbagent docs / `kbagent:kbagent` skill.
+1. **kbagent installed** and on `PATH` (`kbagent --version`). kbagent lives at `https://github.com/keboola/cli` (a separate marketplace from this repo): `/plugin marketplace add keboola/cli` then `/plugin install kbagent@keboola-agent-cli`, or install the standalone CLI directly — see `https://github.com/keboola/cli#install`.
 2. **Project registered** with kbagent (one-time per project):
    ```bash
    kbagent --json project add --project <alias> --stack <stack-url> --storage-token "$KBC_TOKEN"


### PR DESCRIPTION
## Summary
- `plugins/keboola-git/README.md` and `plugins/keboola-git/skills/keboola-git/SKILL.md` both pointed readers looking for kbagent install instructions at "the `keboola-cli` plugin / kbagent docs" — but the `keboola-cli` plugin in this repo documents a completely different product: the older `kbc` CLI (`developers.keboola.com/cli`), not kbagent.
- Nothing in this repo names `keboola/cli` as the marketplace kbagent actually lives in, so both references were unresolvable from where the reader stood — following them lands you on the wrong tool with no path forward.
- Fix: point both references at the real install (`https://github.com/keboola/cli#install`) and name the `/plugin marketplace add keboola/cli` + `/plugin install kbagent@keboola-agent-cli` commands explicitly. Dropped the keboola-git README's "Related" cross-link to the `keboola-cli` plugin entirely, since it isn't about kbagent at all.

Filed against [AI-3750](https://linear.app/keboola/issue/AI-3750/ai-kit-docs-misroute-kbagent-install-points-at-old-kbc-cli-installsh) (Defect 1). Defects 2 & 3 from that issue (a wheel-build crash and an undocumented Python floor) are separate bugs in the `keboola/cli` repo, not this one.

## Test plan
- [x] Grepped this repo for `developers.keboola.com/cli` and `keboola-cli` cross-references after the fix — the only remaining hits are inside `plugins/keboola-cli/` itself, which legitimately documents the old `kbc` CLI it wraps.
- [x] Confirmed the corrected marketplace/plugin names (`keboola-agent-cli` / `kbagent`) against `keboola/cli`'s own `.claude-plugin/marketplace.json`.
- Docs-only change; no scripts/commands/agents added, so no version bump per this repo's `CLAUDE.md` plugin-development convention.

## Related issues
[AI-3750](https://linear.app/keboola/issue/AI-3750/ai-kit-docs-misroute-kbagent-install-points-at-old-kbc-cli-installsh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)