### PR TITLE
docs: document Kai/MCP workspace-ID pinning for data apps

### DIFF
--- a/plugins/dataapp-developer/skills/dataapp-development/references/kai-integration.md
+++ b/plugins/dataapp-developer/skills/dataapp-development/references/kai-integration.md
@@ -67,6 +67,11 @@ Use the SAME Keboola Storage API token the app already has. Pass it on every Kai
 
 No separate Kai token. No OAuth flow on top. If your app authenticates the end user via OIDC (or whatever) you still use the project's Storage token for the Kai call — the end-user identity is conveyed via Kai's chat history association.
 
+**Pin Kai's queries to this app's own workspace.** Keboola injects `WORKSPACE_ID` into every Data App container — forward it as `x-workspace-id` on every Kai request so Kai queries this app's own (often more restricted) workspace instead of the default per-branch one:
+- Header: `x-workspace-id: <WORKSPACE_ID>` (omit when empty — e.g. local dev outside a Data App)
+
+Requires a `kai-client` release that includes the `workspace_id` param on `KaiClient`/`from_storage_api()` ([keboola/kai-client#48](https://github.com/keboola/kai-client/pull/48)). For a JS embed there's nothing to install; just add the header.
+
 ## Pattern A — Streamlit embed
 
 ```python
@@ -93,6 +98,7 @@ async def stream_response(chat_id, prompt):
     client = await KaiClient.from_storage_api(
         storage_api_token=os.environ["KBC_TOKEN"],
         storage_api_url=os.environ["KBC_URL"],
+        workspace_id=os.environ.get("WORKSPACE_ID") or None,  # Keboola injects this in Data Apps
     )
     async with client:
         async for event in client.send_message(chat_id, prompt):
@@ -159,6 +165,8 @@ async function proxySSE(payload, res) {
       'Content-Type': 'application/json',
       'x-storageapi-token': process.env.KBC_TOKEN,
       'x-storageapi-url': process.env.KBC_URL,
+      // Keboola injects WORKSPACE_ID into every Data App container
+      ...(process.env.WORKSPACE_ID && { 'x-workspace-id': process.env.WORKSPACE_ID }),
     },
     body: JSON.stringify(payload),
   });

--- a/plugins/dataapp-developer/skills/mcp-data-app/reference/deploy.md
+++ b/plugins/dataapp-developer/skills/mcp-data-app/reference/deploy.md
@@ -58,6 +58,7 @@ Same three tools as the kbagent driver, called directly as MCP tools rather than
 | `#KBC_STORAGE_TOKEN` | Yes | Storage API token scoping this app to a project |
 | `#MCP_API_KEY` | Yes | Generate with `openssl rand -hex 32` |
 | `#MCP_PUBLIC_URL` | No | Override only. See The app's own URL below |
+| `#KBC_WORKSPACE_ID` | No | Pin tool calls to a specific workspace (e.g. this app's own `WORKSPACE_ID`) instead of the default per-branch one |
 
 Via kbagent: `kbagent --allow-env-manage-token data-app secrets-set --project <alias> --app-id <id> '#KEY=VAL'` then redeploy.
 

--- a/plugins/dataapp-developer/skills/mcp-data-app/template/server.py
+++ b/plugins/dataapp-developer/skills/mcp-data-app/template/server.py
@@ -27,6 +27,12 @@ Required env vars (set as data-app secrets):
 Optional env vars:
     KBC_WORKSPACE_SCHEMA    Schema for SQL transformation tools. Find it in
                             your project's Snowflake/BigQuery workspace.
+    KBC_WORKSPACE_ID        Pin every tool call to this workspace ID instead
+                            of the default per-branch MCP-managed workspace —
+                            e.g. set it to this data app's own WORKSPACE_ID so
+                            queries run under the app's (often more
+                            restricted) permissions. Takes precedence over
+                            KBC_WORKSPACE_SCHEMA when both are set.
     MCP_PUBLIC_URL          Override for this app's externally reachable
                             origin, no trailing slash, no `/mcp`. Normally
                             leave unset: on Keboola the platform injects


### PR DESCRIPTION
## Summary
- Follow-up to [keboola/mcp-server#654](https://github.com/keboola/mcp-server/pull/654) ([AI-3669](https://linear.app/keboola/issue/AI-3669/use-app-workspace-for-kai-queries-in-apps)) and [keboola/kai-client#48](https://github.com/keboola/kai-client/pull/48) (draft, not yet merged/released), which add `workspace_id` / `X-Workspace-Id` support so Kai's queries (and a hosted raw MCP server) can be pinned to a specific Keboola workspace instead of the default per-branch one. The main use case: Kai embedded in a Data App should query that app's own — often more restricted — workspace.
- `dataapp-development/references/kai-integration.md`: documents forwarding the Data App's own `WORKSPACE_ID` env var as the `x-workspace-id` header in both the Streamlit and JS Kai-embed patterns, plus a note in the Authentication section.
- `mcp-data-app` skill (`template/server.py` docstring, `reference/deploy.md` secrets table): documents the optional `KBC_WORKSPACE_ID` env var — the hosted MCP server template already picks this up for free since `Config.from_dict(dict(os.environ))` reads all `KBC_`-prefixed vars generically, so this is a docs-only change, no code change needed.

## Test plan
- [x] Docs-only change — no code paths affected.
- [ ] Re-verify the `kai-integration.md` code samples once `keboola/kai-client#48` merges and a release ships with `workspace_id` support (the samples reference that PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)