### PR TITLE
chore(kbagent): publish v0.91.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,12 +27,12 @@
     {
       "name": "kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, sync configs as files, manage dev branches, and debug SQL in workspaces",
-      "version": "0.89.0",
+      "version": "0.91.0",
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/keboola/cli.git",
         "path": "plugins/kbagent",
-        "ref": "v0.89.0"
+        "ref": "v0.91.0"
       },
       "category": "development"
     },


### PR DESCRIPTION
Automated by `release-kbagent` in `keboola/cli` on tag `v0.91.0`.

Points the `kbagent` marketplace entry at `v0.91.0` (`version` + `source.ref`).
The plugin SOURCE lives in `keboola/cli` under `plugins/kbagent/`, where the CI gates
that generate and validate it against the live command tree run; this repo publishes
it. Merging this PR is what moves `keboola-claude-kit` users onto the new version.

Release: https://github.com/keboola/cli/releases/tag/v0.91.0
